### PR TITLE
don't abort test on a single tester error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/livekit/server-sdk-go v0.9.3
 	github.com/pion/rtp v1.7.4
 	github.com/pion/webrtc/v3 v3.1.25-0.20220225075517-37e16a3b15a3
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli/v2 v2.3.0
 	go.uber.org/atomic v1.9.0
@@ -47,7 +48,6 @@ require (
 	github.com/pion/transport v0.13.0 // indirect
 	github.com/pion/turn/v2 v2.0.8 // indirect
 	github.com/pion/udp v0.1.1 // indirect
-	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect

--- a/pkg/loadtester/loadtest.go
+++ b/pkg/loadtester/loadtest.go
@@ -300,6 +300,8 @@ func (t *LoadTest) run(params Params) (map[string]*testerStats, error) {
 		// a really long time
 		duration = 1000 * time.Hour
 	}
+	fmt.Printf("Finished connecting to room, waiting %s\n", duration.String())
+
 	select {
 	case <-params.Context.Done():
 		// canceled

--- a/pkg/loadtester/loadtester.go
+++ b/pkg/loadtester/loadtester.go
@@ -7,13 +7,14 @@ import (
 	"sync"
 	"time"
 
-	provider2 "github.com/livekit/livekit-cli/pkg/provider"
-	"github.com/livekit/protocol/livekit"
-	"github.com/livekit/server-sdk-go/pkg/samplebuilder"
 	"github.com/pion/rtp"
 	"github.com/pion/rtp/codecs"
 	"github.com/pion/webrtc/v3"
 	"go.uber.org/atomic"
+
+	provider2 "github.com/livekit/livekit-cli/pkg/provider"
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/server-sdk-go/pkg/samplebuilder"
 
 	lksdk "github.com/livekit/server-sdk-go"
 )
@@ -310,7 +311,7 @@ func (t *LoadTester) onTrackSubscribed(track *webrtc.TrackRemote, pub *lksdk.Rem
 func (t *LoadTester) consumeTrack(track *webrtc.TrackRemote, pub *lksdk.RemoteTrackPublication, rp *lksdk.RemoteParticipant) {
 	rp.WritePLI(track.SSRC())
 
-	go func() {
+	defer func() {
 		if e := recover(); e != nil {
 			fmt.Println("caught panic in consumeTrack", e)
 		}

--- a/pkg/loadtester/stats.go
+++ b/pkg/loadtester/stats.go
@@ -3,13 +3,15 @@ package loadtester
 import (
 	"time"
 
-	lksdk "github.com/livekit/server-sdk-go"
 	"go.uber.org/atomic"
+
+	lksdk "github.com/livekit/server-sdk-go"
 )
 
 type testerStats struct {
 	expectedTracks int
 	trackStats     map[string]*trackStats
+	err            error
 }
 
 type trackStats struct {
@@ -32,6 +34,8 @@ type summary struct {
 	latencyCount int64
 	dropped      int64
 	elapsed      time.Duration
+	errString    string
+	errCount     int64
 }
 
 func getTestSummary(summaries map[string]*summary) *summary {
@@ -47,6 +51,7 @@ func getTestSummary(summaries map[string]*summary) *summary {
 		if testerSummary.elapsed > s.elapsed {
 			s.elapsed = testerSummary.elapsed
 		}
+		s.errCount += testerSummary.errCount
 	}
 	return s
 }
@@ -66,6 +71,12 @@ func getTesterSummary(testerStats *testerStats) *summary {
 		if elapsed > s.elapsed {
 			s.elapsed = elapsed
 		}
+	}
+	if testerStats.err == nil {
+		s.errString = "-"
+	} else {
+		s.errString = testerStats.err.Error()
+		s.errCount = 1
 	}
 	return s
 }


### PR DESCRIPTION
Output errors in summary:
```
Summary | Tester | Tracks | Bitrate                 | Latency | Total Dropped | Error
        | Sub 0  | 2/0    | 175.0kbps               |  -      | 0 (0%)        | -
        | Sub 1  | 2/0    | 150.9kbps               |  -      | 0 (0%)        | -
        | Sub 2  | 2/0    | 152.0kbps               |  -      | 0 (0%)        | -
        | Sub 3  | 2/0    | 151.2kbps               |  -      | 0 (0%)        | -
        | Sub 4  | 2/0    | 149.0kbps               |  -      | 0 (0%)        | -
        | Sub 5  | 2/0    | 149.0kbps               |  -      | 0 (0%)        | -
        | Sub 6  | 2/0    | 134.8kbps               |  -      | 0 (0%)        | -
        | Sub 7  | 2/0    | 133.9kbps               |  -      | 0 (0%)        | -
        | Sub 8  | 2/0    | 134.2kbps               |  -      | 0 (0%)        | -
        | Sub 9  | 2/0    | 134.8kbps               |  -      | 0 (0%)        | -
        | Total  | 20/0   | 1.3mbps (125.8kbps avg) |  -      | 0 (0%)        | 0
```