### PR TITLE
Update release.yml to dereference files from Git LFS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,15 @@ jobs:
     name: Generate cross-platform builds
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout the repository
+      - name: Checkout Git LFS
         uses: actions/checkout@v2
+        with:
+          lfs: 'true'
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - run: git lfs pull
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
This PR intends to fix issue #27 where an error occured in v0.8.0 because the build doesn't pull the LFS files in `pkg/provider/resources`.

In order to solve this problem, we just have to tell the workflow in `.github/workflows/release.yml` to download the LFS files so it's included in the build. But, there's a currently ongoing issue with the LFS that you can see [here](https://github.com/actions/checkout/issues/270).

You can see the sample release files from the updated release.yml [in my fork](https://github.com/stevenhansel/livekit-cli/releases/tag/v0.8.1) 