### PR TITLE
Support TCP sockets in addition to Unix sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ Refer to [encoding instructions](https://github.com/livekit/server-sdk-go/tree/m
   --fps 23.98
 ```
 
-This will publish the pre-encoded ivf and ogg files to the room, indicating video FPS of 23.98. Note that the FPS only affects the video; it's important to match video framerate with the source to prevent out of sync issues. 
+This will publish the pre-encoded ivf and ogg files to the room, indicating video FPS of 23.98. Note that the FPS only affects the video; it's important to match video framerate with the source to prevent out of sync issues.
 
 ### Publish from FFmpeg
 
 It's possible to publish any source that FFmpeg supports (including live sources such as RTSP) by using it as a transcoder.
 
-This is done by running FFmpeg in a separate process, encoding to a Unix socket. (not available on Windows). 
+This is done by running FFmpeg in a separate process, encoding to a Unix socket. (not available on Windows).
 `livekit-cli` can then read transcoded data from the socket and publishing them to the room.
 
 First run FFmpeg like this:
@@ -83,18 +83,29 @@ $ ffmpeg -i <video-file | rtsp://url> \
   	-listen 1 -f opus unix:/tmp/myvideo.opus.sock
 ```
 
-This transcodes the input into H.264 baseline profile and Opus. 
+This transcodes the input into H.264 baseline profile and Opus.
 Your output sockets must contain the string `opus`, `h264`, or `vp8`, as the CLI infers encoding from socket path.
 
 Then, run `livekit-cli` like this:
 
 ```shell
 $ livekit-cli join-room --room yourroom --identity bot \
-  --publish unix:/tmp/myvideo.h264.sock \
-  --publish unix:/tmp/myvideo.opus.sock
+  --publish h264:///tmp/myvideo.h264.sock \
+  --publish opus:///tmp/myvideo.opus.sock
 ````
 
 You should now see both video and audio tracks published to the room.
+
+### Publish from TCP (i.e. gstreamer)
+
+It's possible to publish from video streams coming over a TCP socket. `livekit-cli` can act as a TCP client. For example, with a gstreamer pipeline ending in `! tcpserversink port=16400` and streaming H.264.
+
+Run `livekit-cli` like this:
+
+```shell
+$ livekit-cli join-room --room yourroom --identity bot \
+  --publish h264:///127.0.0.1:16400
+```
 
 ### Publish streams from your application
 

--- a/cmd/livekit-cli/join.go
+++ b/cmd/livekit-cli/join.go
@@ -110,11 +110,13 @@ func joinRoom(c *cli.Context) error {
 
 func handlePublish(room *lksdk.Room, name string, fps float64) error {
 	// See if we're dealing with a socket
-	mime_type, socket_type, address, err := parseSocketFromName(name)
-	if (err == nil) {
+	if isSocketFormat(name) {
+		mime_type, socket_type, address, err := parseSocketFromName(name)
+		if (err != nil) {
+			return err
+		}
 		return publishSocket(room, mime_type, socket_type, address, fps)
 	}
-
 	// Else, handle file
 	return publishFile(room, name, fps)
 }
@@ -202,6 +204,14 @@ func parseSocketFromName(name string) (string, string, string, error) {
 	}
 
 	return mime_type, "tcp", address, nil
+}
+
+func isSocketFormat(name string) bool {
+	const mime_delimiter = "://"
+	if strings.Index(name, mime_delimiter) != -1 {
+		return true
+	}
+	return false
 }
 
 func publishSocket(room *lksdk.Room, mime_type string, socket_type string, address string, fps float64) error {

--- a/cmd/livekit-cli/join.go
+++ b/cmd/livekit-cli/join.go
@@ -197,6 +197,10 @@ func parseSocketFromName(name string) (string, string, string, error) {
 
 	address := name[mime_delimiter_offset+len(mime_delimiter):]
 
+	if len(address) == 0 {
+		return "", "", "", fmt.Errorf("address cannot be empty. input was: %s", name)
+	}
+
 	// If the address doesn't contain a ':' we assume it's a unix socket
 	if !strings.Contains(address, ":") {
 		return mime_type, "unix", address, nil

--- a/cmd/livekit-cli/join.go
+++ b/cmd/livekit-cli/join.go
@@ -41,7 +41,7 @@ var (
 					Name: "publish",
 					Usage: "files to publish as tracks to room (supports .h264, .ivf, .ogg). " +
 						"can be used multiple times to publish multiple files. " +
-						"can publish from Unix or TCP socket using the format `codec://socket_name` or `codec://host:address` respectively.",
+						"can publish from Unix or TCP socket using the format `codec://socket_name` or `codec://host:address` respectively. Valid codecs are h264, vp8, opus",
 				},
 				&cli.Float64Flag{
 					Name:  "fps",

--- a/cmd/livekit-cli/join.go
+++ b/cmd/livekit-cli/join.go
@@ -108,8 +108,8 @@ func joinRoom(c *cli.Context) error {
 }
 
 func handlePublish(room *lksdk.Room, name string, fps float64) error {
-	// Handle socket
-	if strings.Contains(name, "unix:") || strings.Contains(name, "tcp:") || strings.Contains(name, "udp:") {
+	// Handle socket (either unix domain socket )
+	if strings.Contains(name, "unix:") || strings.Contains(name, "tcp:") {
 		return publishSocket(room, name, fps)
 	}
 	// Else, handle file
@@ -175,7 +175,7 @@ func publishFile(room *lksdk.Room, filename string, fps float64) error {
 }
 
 func publishSocket(room *lksdk.Room, name string, fps float64) error {
-	// Precondition that name starts with unix:, tcp:, or udp:
+	// Precondition that name starts with unix: or tcp:
 	var addr = ""
 	var sock_type = ""
 
@@ -185,9 +185,6 @@ func publishSocket(room *lksdk.Room, name string, fps float64) error {
 	} else if strings.Contains(name, "tcp:") {
 		addr = strings.ReplaceAll(name, "tcp:", "")
 		sock_type = "tcp"
-	} else if strings.Contains(name, "udp:") {
-		sock_type = "udp"
-		addr = strings.ReplaceAll(name, "udp:", "")
 	}
 
 	// Dial Unix socket
@@ -196,8 +193,7 @@ func publishSocket(room *lksdk.Room, name string, fps float64) error {
 		return err
 	}
 
-	// TODO (bsirang) extract mime from name string similar to socket type above
-	// Default to H264 for now
+	// TODO (bsirang) extract mime type from name string (forcing h264 for now)
 	mime := webrtc.MimeTypeH264
 
 	// Publish to room

--- a/cmd/livekit-cli/join.go
+++ b/cmd/livekit-cli/join.go
@@ -182,7 +182,8 @@ func parseSocketFromName(name string) (string, string, string, error) {
 	// e.g. h264://192.168.0.1:1234 (tcp)
 	// e.g. opus:///tmp/my.socket (unix domain socket)
 
-	mime_delimiter_offset := strings.Index(name, "://")
+	const mime_delimiter = "://"
+	mime_delimiter_offset := strings.Index(name, mime_delimiter)
 	if (mime_delimiter_offset == -1) {
 		return "", "", "", errors.New("bad format")
 	}
@@ -193,7 +194,7 @@ func parseSocketFromName(name string) (string, string, string, error) {
 		return "", "", "", errors.New("unsupported mime type")
 	}
 
-	address := name[mime_delimiter_offset+3:]
+	address := name[mime_delimiter_offset+len(mime_delimiter):]
 
 	// If the address doesn't contain a ':' we assume it's a unix socket
 	if (strings.Index(address, ":") == -1) {

--- a/cmd/livekit-cli/join.go
+++ b/cmd/livekit-cli/join.go
@@ -196,18 +196,9 @@ func publishSocket(room *lksdk.Room, name string, fps float64) error {
 		return err
 	}
 
-	// Determine mime type
-	var mime string
-	switch {
-	case strings.Contains(addr, "h264"):
-		mime = webrtc.MimeTypeH264
-	case strings.Contains(addr, "vp8"):
-		mime = webrtc.MimeTypeVP8
-	case strings.Contains(addr, "opus"):
-		mime = webrtc.MimeTypeOpus
-	default:
-		return lksdk.ErrUnsupportedFileType
-	}
+	// TODO (bsirang) extract mime from name string similar to socket type above
+	// Default to H264 for now
+	mime := webrtc.MimeTypeH264
 
 	// Publish to room
 	err = publishReader(room, sock, mime, fps)

--- a/cmd/livekit-cli/join.go
+++ b/cmd/livekit-cli/join.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -187,13 +186,13 @@ func parseSocketFromName(name string) (string, string, string, error) {
 	const mime_delimiter = "://"
 	mime_delimiter_offset := strings.Index(name, mime_delimiter)
 	if (mime_delimiter_offset == -1) {
-		return "", "", "", errors.New("bad format")
+		return "", "", "", fmt.Errorf("did not find delimiter %s in %s", mime_delimiter, name)
 	}
 
 	mime_type := name[:mime_delimiter_offset]
 
 	if (mime_type != "h264" && mime_type != "vp8" && mime_type != "opus") {
-		return "", "", "", errors.New("unsupported mime type")
+		return "", "", "", fmt.Errorf("unsupported mime type: %s", mime_type)
 	}
 
 	address := name[mime_delimiter_offset+len(mime_delimiter):]

--- a/cmd/livekit-cli/join.go
+++ b/cmd/livekit-cli/join.go
@@ -42,7 +42,7 @@ var (
 					Name: "publish",
 					Usage: "files to publish as tracks to room (supports .h264, .ivf, .ogg). " +
 						"can be used multiple times to publish multiple files. " +
-						"can publish from Unix socket using the format `unix:{socket-name}`; socket name must contain one of the keywords: h264, vp8, opus",
+						"can publish from Unix or TCP socket using the format `codec://socket_name` or `codec://host:address` respectively.",
 				},
 				&cli.Float64Flag{
 					Name:  "fps",
@@ -179,9 +179,9 @@ func publishFile(room *lksdk.Room, filename string, fps float64) error {
 
 func parseSocketFromName(name string) (string, string, string, error) {
 	// Extract mime type, socket type, and address
-
 	// e.g. h264://192.168.0.1:1234 (tcp)
 	// e.g. opus:///tmp/my.socket (unix domain socket)
+
 	mime_delimiter_offset := strings.Index(name, "://")
 	if (mime_delimiter_offset == -1) {
 		return "", "", "", errors.New("bad format")

--- a/cmd/livekit-cli/join.go
+++ b/cmd/livekit-cli/join.go
@@ -109,9 +109,8 @@ func joinRoom(c *cli.Context) error {
 
 func handlePublish(room *lksdk.Room, name string, fps float64) error {
 	// Handle socket
-	if strings.Contains(name, "unix:") {
-		addr := strings.ReplaceAll(name, "unix:", "")
-		return publishSocket(room, addr, fps)
+	if strings.Contains(name, "unix:") || strings.Contains(name, "tcp:") || strings.Contains(name, "udp:") {
+		return publishSocket(room, name, fps)
 	}
 	// Else, handle file
 	return publishFile(room, name, fps)
@@ -175,9 +174,24 @@ func publishFile(room *lksdk.Room, filename string, fps float64) error {
 	return err
 }
 
-func publishSocket(room *lksdk.Room, addr string, fps float64) error {
+func publishSocket(room *lksdk.Room, name string, fps float64) error {
+	// Precondition that name starts with unix:, tcp:, or udp:
+	var addr = ""
+	var sock_type = ""
+
+	if strings.Contains(name, "unix:") {
+		addr = strings.ReplaceAll(name, "unix:", "")
+		sock_type = "unix"
+	} else if strings.Contains(name, "tcp:") {
+		addr = strings.ReplaceAll(name, "tcp:", "")
+		sock_type = "tcp"
+	} else if strings.Contains(name, "udp:") {
+		sock_type = "udp"
+		addr = strings.ReplaceAll(name, "udp:", "")
+	}
+
 	// Dial Unix socket
-	sock, err := net.Dial("unix", addr)
+	sock, err := net.Dial(sock_type, addr)
 	if err != nil {
 		return err
 	}

--- a/cmd/livekit-cli/join.go
+++ b/cmd/livekit-cli/join.go
@@ -198,7 +198,7 @@ func parseSocketFromName(name string) (string, string, string, error) {
 	address := name[mime_delimiter_offset+len(mime_delimiter):]
 
 	// If the address doesn't contain a ':' we assume it's a unix socket
-	if (strings.Index(address, ":") == -1) {
+	if !strings.Contains(address, ":") {
 		return mime_type, "unix", address, nil
 	}
 
@@ -207,10 +207,7 @@ func parseSocketFromName(name string) (string, string, string, error) {
 
 func isSocketFormat(name string) bool {
 	const mime_delimiter = "://"
-	if strings.Index(name, mime_delimiter) != -1 {
-		return true
-	}
-	return false
+	return strings.Contains(name, mime_delimiter)
 }
 
 func publishSocket(room *lksdk.Room, mime_type string, socket_type string, address string, fps float64) error {

--- a/cmd/livekit-cli/join_test.go
+++ b/cmd/livekit-cli/join_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+    "testing"
+    "github.com/stretchr/testify/assert"
+)
+
+func TestSocketFormat(t *testing.T) {
+  result := isSocketFormat("")
+  assert.False(t, result, "Empty string should return false")
+
+  result = isSocketFormat("://")
+  assert.True(t, result, "Just the delimiter should return true")
+
+  result = isSocketFormat("foo:/bar")
+  assert.False(t, result, "Invalid delimiter should return false")
+
+  result = isSocketFormat("foo://bar")
+  assert.True(t, result, "Longer string with delimiter should return true")
+}
+
+func TestParseSocketString(t *testing.T) {
+  mime_type, socket_type, address, err := parseSocketFromName("://")
+  assert.Equal(t, mime_type, "")
+  assert.Equal(t, socket_type, "")
+  assert.Equal(t, address, "")
+  assert.NotEqual(t, err, nil, "Expected an error due to empty protocol string")
+
+  mime_type, socket_type, address, err = parseSocketFromName("foo://")
+  assert.Equal(t, mime_type, "")
+  assert.Equal(t, socket_type, "")
+  assert.Equal(t, address, "")
+  assert.NotEqual(t, err, nil, "Expected an error due to invalid protocol string")
+
+  mime_type, socket_type, address, err = parseSocketFromName("foo://")
+  assert.Equal(t, mime_type, "")
+  assert.Equal(t, socket_type, "")
+  assert.Equal(t, address, "")
+  assert.NotEqual(t, err, nil, "Expected an error due to invalid protocol string")
+
+  mime_type, socket_type, address, err = parseSocketFromName("h264://")
+  assert.Equal(t, mime_type, "")
+  assert.Equal(t, socket_type, "")
+  assert.Equal(t, address, "")
+  assert.NotEqual(t, err, nil, "Expected error for h264 socket with empty address")
+
+  mime_type, socket_type, address, err = parseSocketFromName("h264:///path/to/socket")
+  assert.Equal(t, mime_type, "h264")
+  assert.Equal(t, socket_type, "unix")
+  assert.Equal(t, address, "/path/to/socket")
+  assert.Equal(t, err, nil, "Expected no error for valid h264 socket")
+
+  mime_type, socket_type, address, err = parseSocketFromName("opus://foobar.com:1234")
+  assert.Equal(t, mime_type, "opus")
+  assert.Equal(t, socket_type, "tcp")
+  assert.Equal(t, address, "foobar.com:1234")
+  assert.Equal(t, err, nil, "Expected no error for valid opus TCP socket")
+
+  mime_type, socket_type, address, err = parseSocketFromName("opus://foobar.com:1234")
+  assert.Equal(t, mime_type, "opus")
+  assert.Equal(t, socket_type, "tcp")
+  assert.Equal(t, address, "foobar.com:1234")
+  assert.Equal(t, err, nil, "Expected no error for valid opus TCP socket")
+
+
+  mime_type, socket_type, address, err = parseSocketFromName("vp8://foobar.com:1234")
+  assert.Equal(t, mime_type, "vp8")
+  assert.Equal(t, socket_type, "tcp")
+  assert.Equal(t, address, "foobar.com:1234")
+  assert.Equal(t, err, nil, "Expected no error for valid vp8 TCP socket")
+}


### PR DESCRIPTION
Adds support for TCP sockets.

Using a new format for the "name" string passed in via `--publish`

The format is `mime_type://address:port` in the case of TCP or `mime_type:://unix_socket/path` in the case of unix sockets

The existence of the second `:` in the string is used to assume a TCP endpoint in the address:port format.