### PR TITLE
Introducing `project` subcommand

### DIFF
--- a/cmd/livekit-cli/egress.go
+++ b/cmd/livekit-cli/egress.go
@@ -10,7 +10,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/ggwhite/go-masker"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/browser"
 	"github.com/urfave/cli/v2"
@@ -32,17 +31,13 @@ var (
 			Before:   createEgressClient,
 			Action:   startRoomCompositeEgress,
 			Category: egressCategory,
-			Flags: []cli.Flag{
-				urlFlag,
-				apiKeyFlag,
-				secretFlag,
-				verboseFlag,
+			Flags: withDefaultFlags(
 				&cli.StringFlag{
 					Name:     "request",
 					Usage:    "RoomCompositeEgressRequest as json file (see livekit-cli/examples)",
 					Required: true,
 				},
-			},
+			),
 		},
 		{
 			Name:     "start-track-composite-egress",
@@ -50,17 +45,13 @@ var (
 			Before:   createEgressClient,
 			Action:   startTrackCompositeEgress,
 			Category: egressCategory,
-			Flags: []cli.Flag{
-				urlFlag,
-				apiKeyFlag,
-				secretFlag,
-				verboseFlag,
+			Flags: withDefaultFlags(
 				&cli.StringFlag{
 					Name:     "request",
 					Usage:    "TrackCompositeEgressRequest as json file (see livekit-cli/examples)",
 					Required: true,
 				},
-			},
+			),
 		},
 		{
 			Name:     "start-track-egress",
@@ -68,17 +59,13 @@ var (
 			Before:   createEgressClient,
 			Action:   startTrackEgress,
 			Category: egressCategory,
-			Flags: []cli.Flag{
-				urlFlag,
-				apiKeyFlag,
-				secretFlag,
-				verboseFlag,
+			Flags: withDefaultFlags(
 				&cli.StringFlag{
 					Name:     "request",
 					Usage:    "TrackEgressRequest as json file (see livekit-cli/examples)",
 					Required: true,
 				},
-			},
+			),
 		},
 		{
 			Name:     "list-egress",
@@ -86,16 +73,13 @@ var (
 			Before:   createEgressClient,
 			Action:   listEgress,
 			Category: egressCategory,
-			Flags: []cli.Flag{
-				urlFlag,
-				apiKeyFlag,
-				secretFlag,
+			Flags: withDefaultFlags(
 				&cli.StringFlag{
 					Name:     "room",
 					Usage:    "limits list to a certain room name",
 					Required: false,
 				},
-			},
+			),
 		},
 		{
 			Name:     "update-layout",
@@ -103,10 +87,7 @@ var (
 			Before:   createEgressClient,
 			Action:   updateLayout,
 			Category: egressCategory,
-			Flags: []cli.Flag{
-				urlFlag,
-				apiKeyFlag,
-				secretFlag,
+			Flags: withDefaultFlags(
 				&cli.StringFlag{
 					Name:     "id",
 					Usage:    "Egress ID",
@@ -117,7 +98,7 @@ var (
 					Usage:    "new web layout",
 					Required: true,
 				},
-			},
+			),
 		},
 		{
 			Name:     "update-stream",
@@ -125,10 +106,7 @@ var (
 			Before:   createEgressClient,
 			Action:   updateStream,
 			Category: egressCategory,
-			Flags: []cli.Flag{
-				urlFlag,
-				apiKeyFlag,
-				secretFlag,
+			Flags: withDefaultFlags(
 				&cli.StringFlag{
 					Name:     "id",
 					Usage:    "Egress ID",
@@ -144,7 +122,7 @@ var (
 					Usage:    "urls to remove",
 					Required: false,
 				},
-			},
+			),
 		},
 		{
 			Name:     "stop-egress",
@@ -152,26 +130,20 @@ var (
 			Before:   createEgressClient,
 			Action:   stopEgress,
 			Category: egressCategory,
-			Flags: []cli.Flag{
-				urlFlag,
-				apiKeyFlag,
-				secretFlag,
+			Flags: withDefaultFlags(
 				&cli.StringFlag{
 					Name:     "id",
 					Usage:    "Egress ID",
 					Required: true,
 				},
-			},
+			),
 		},
 		{
 			Name:     "test-egress-template",
 			Usage:    "See what your egress template will look like in a recording",
 			Category: egressCategory,
 			Action:   testEgressTemplate,
-			Flags: []cli.Flag{
-				urlFlag,
-				apiKeyFlag,
-				secretFlag,
+			Flags: withDefaultFlags(
 				&cli.StringFlag{
 					Name:     "base-url (e.g. https://recorder.livekit.io/#)",
 					Usage:    "base template url",
@@ -191,7 +163,7 @@ var (
 					Usage:    "name of the room",
 					Required: false,
 				},
-			},
+			),
 			SkipFlagParsing:        false,
 			HideHelp:               false,
 			HideHelpCommand:        false,
@@ -206,18 +178,12 @@ var (
 )
 
 func createEgressClient(c *cli.Context) error {
-	url := c.String("url")
-	apiKey := c.String("api-key")
-	apiSecret := c.String("api-secret")
-
-	if c.Bool("verbose") {
-		fmt.Printf("creating client to %s, with api-key: %s, secret: %s\n",
-			url,
-			masker.ID(apiKey),
-			masker.ID(apiSecret))
+	pc, err := loadProjectDetails(c)
+	if err != nil {
+		return err
 	}
 
-	egressClient = lksdk.NewEgressClient(url, apiKey, apiSecret)
+	egressClient = lksdk.NewEgressClient(pc.URL, pc.APIKey, pc.APISecret)
 	return nil
 }
 

--- a/cmd/livekit-cli/ingress.go
+++ b/cmd/livekit-cli/ingress.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/ggwhite/go-masker"
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v2"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -25,17 +24,13 @@ var (
 			Before:   createIngressClient,
 			Action:   createIngress,
 			Category: ingressCategory,
-			Flags: []cli.Flag{
-				urlFlag,
-				apiKeyFlag,
-				secretFlag,
-				verboseFlag,
+			Flags: withDefaultFlags(
 				&cli.StringFlag{
 					Name:     "request",
 					Usage:    "CreateIngressRequest as json file (see livekit-cli/examples)",
 					Required: true,
 				},
-			},
+			),
 		},
 		{
 			Name:     "update-ingress",
@@ -43,17 +38,13 @@ var (
 			Before:   createIngressClient,
 			Action:   updateIngress,
 			Category: ingressCategory,
-			Flags: []cli.Flag{
-				urlFlag,
-				apiKeyFlag,
-				secretFlag,
-				verboseFlag,
+			Flags: withDefaultFlags(
 				&cli.StringFlag{
 					Name:     "request",
 					Usage:    "UpdateIngressRequest as json file (see livekit-cli/examples)",
 					Required: true,
 				},
-			},
+			),
 		},
 		{
 			Name:     "list-ingress",
@@ -61,16 +52,13 @@ var (
 			Before:   createIngressClient,
 			Action:   listIngress,
 			Category: ingressCategory,
-			Flags: []cli.Flag{
-				urlFlag,
-				apiKeyFlag,
-				secretFlag,
+			Flags: withDefaultFlags(
 				&cli.StringFlag{
 					Name:     "room",
 					Usage:    "limits list to a certain room name ",
 					Required: false,
 				},
-			},
+			),
 		},
 		{
 			Name:     "delete-ingress",
@@ -78,16 +66,13 @@ var (
 			Before:   createIngressClient,
 			Action:   deleteIngress,
 			Category: ingressCategory,
-			Flags: []cli.Flag{
-				urlFlag,
-				apiKeyFlag,
-				secretFlag,
+			Flags: withDefaultFlags(
 				&cli.StringFlag{
 					Name:     "id",
 					Usage:    "Ingress ID",
 					Required: true,
 				},
-			},
+			),
 		},
 	}
 
@@ -95,18 +80,12 @@ var (
 )
 
 func createIngressClient(c *cli.Context) error {
-	url := c.String("url")
-	apiKey := c.String("api-key")
-	apiSecret := c.String("api-secret")
-
-	if c.Bool("verbose") {
-		fmt.Printf("creating client to %s, with api-key: %s, secret: %s\n",
-			url,
-			masker.ID(apiKey),
-			masker.ID(apiSecret))
+	pc, err := loadProjectDetails(c)
+	if err != nil {
+		return err
 	}
 
-	ingressClient = lksdk.NewIngressClient(url, apiKey, apiSecret)
+	ingressClient = lksdk.NewIngressClient(pc.URL, pc.APIKey, pc.APISecret)
 	return nil
 }
 

--- a/cmd/livekit-cli/loadtest.go
+++ b/cmd/livekit-cli/loadtest.go
@@ -20,10 +20,7 @@ var LoadTestCommands = []*cli.Command{
 		Usage:    "Run load tests against LiveKit with simulated publishers & subscribers",
 		Category: "Simulate",
 		Action:   loadTest,
-		Flags: []cli.Flag{
-			urlFlag,
-			apiKeyFlag,
-			secretFlag,
+		Flags: withDefaultFlags(
 			&cli.StringFlag{
 				Name:  "room",
 				Usage: "name of the room (default to random name)",
@@ -78,14 +75,16 @@ var LoadTestCommands = []*cli.Command{
 				Usage:  "runs set list of load test cases",
 				Hidden: true,
 			},
-			&cli.BoolFlag{
-				Name: "verbose",
-			},
-		},
+		),
 	},
 }
 
 func loadTest(c *cli.Context) error {
+	pc, err := loadProjectDetails(c)
+	if err != nil {
+		return err
+	}
+
 	if !c.Bool("verbose") {
 		lksdk.SetLogger(logr.Discard())
 	}
@@ -109,9 +108,9 @@ func loadTest(c *cli.Context) error {
 		NumPerSecond:    c.Float64("num-per-second"),
 		Simulcast:       !c.Bool("no-simulcast"),
 		TesterParams: loadtester.TesterParams{
-			URL:            c.String("url"),
-			APIKey:         c.String("api-key"),
-			APISecret:      c.String("api-secret"),
+			URL:            pc.URL,
+			APIKey:         pc.APIKey,
+			APISecret:      pc.APISecret,
 			Room:           c.String("room"),
 			IdentityPrefix: c.String("identity-prefix"),
 			Layout:         layout,

--- a/cmd/livekit-cli/main.go
+++ b/cmd/livekit-cli/main.go
@@ -32,6 +32,7 @@ func main() {
 	app.Commands = append(app.Commands, EgressCommands...)
 	app.Commands = append(app.Commands, IngressCommands...)
 	app.Commands = append(app.Commands, LoadTestCommands...)
+	app.Commands = append(app.Commands, ProjectCommands...)
 
 	if err := app.Run(os.Args); err != nil {
 		fmt.Println(err)

--- a/cmd/livekit-cli/project.go
+++ b/cmd/livekit-cli/project.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/manifoldco/promptui"
+	"github.com/olekukonko/tablewriter"
+	"github.com/urfave/cli/v2"
+
+	"github.com/livekit/livekit-cli/pkg/config"
+)
+
+var (
+	ProjectCommands = []*cli.Command{
+		{
+			Name:     "project",
+			Usage:    "subcommand for project management",
+			Category: "Project Management",
+			Before:   loadProjectConfig,
+			Subcommands: []*cli.Command{
+				{
+					Name:   "add",
+					Usage:  "add a new project",
+					Action: addProject,
+				},
+				{
+					Name:   "list",
+					Usage:  "list all configured projects",
+					Action: listProjects,
+				},
+				{
+					Name:      "remove",
+					Usage:     "remove an existing project from config",
+					UsageText: "livekit-cli project remove <project-name>",
+					Action:    removeProject,
+				},
+				{
+					Name:      "set-default",
+					Usage:     "set a project as default to use with other commands",
+					UsageText: "livekit-cli project set-default <project-name>",
+					Action:    setDefaultProject,
+				},
+			},
+		},
+	}
+
+	cliConfig      *config.CLIConfig
+	defaultProject *config.ProjectConfig
+	nameRegex      = regexp.MustCompile(`^[a-zA-Z0-9_\-]+$`)
+)
+
+func loadProjectConfig(c *cli.Context) error {
+	conf, err := config.LoadOrCreate()
+	if err != nil {
+		return err
+	}
+	cliConfig = conf
+
+	if cliConfig.DefaultProject != "" {
+		for _, p := range cliConfig.Projects {
+			if p.Name == cliConfig.DefaultProject {
+				defaultProject = &p
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func addProject(c *cli.Context) error {
+	p := config.ProjectConfig{}
+	fmt.Println("Enter project details")
+	prompt := promptui.Prompt{
+		Label: "URL",
+		Validate: func(val string) error {
+			if !strings.HasPrefix(val, "http") && !strings.HasPrefix(val, "ws") {
+				return errors.New("scheme must be http(s) or ws(s)")
+			}
+			_, err := url.Parse(val)
+			return err
+		},
+	}
+	var err error
+	if p.URL, err = prompt.Run(); err != nil {
+		return err
+	}
+
+	prompt = promptui.Prompt{
+		Label: "API Key",
+		Validate: func(val string) error {
+			if len(val) < 3 {
+				return errors.New("API key must be at least 3 characters")
+			}
+			return nil
+		},
+	}
+	if p.APIKey, err = prompt.Run(); err != nil {
+		return err
+	}
+
+	prompt = promptui.Prompt{
+		Label: "API APISecret",
+		Validate: func(val string) error {
+			if len(val) < 3 {
+				return errors.New("API secret must be at least 3 characters")
+			}
+			return nil
+		},
+	}
+	if p.APISecret, err = prompt.Run(); err != nil {
+		return err
+	}
+
+	prompt = promptui.Prompt{
+		Label: "Name",
+		Validate: func(val string) error {
+			if !nameRegex.MatchString(val) {
+				return errors.New("name can only contain alphanumeric characters, dashes and underscores")
+			}
+			// cannot conflict with existing projects
+			for _, p := range cliConfig.Projects {
+				if p.Name == val {
+					return errors.New("name already exists")
+				}
+			}
+			return nil
+		},
+	}
+	if p.Name, err = prompt.Run(); err != nil {
+		return err
+	}
+
+	// if it's first project, make it default
+	if defaultProject != nil {
+		prompt = promptui.Prompt{
+			Label:     "Make this project default?",
+			IsConfirm: true,
+		}
+		if _, err = prompt.Run(); err != nil && err != promptui.ErrAbort {
+			return err
+		}
+		if err == nil {
+			cliConfig.DefaultProject = p.Name
+		}
+	} else {
+		cliConfig.DefaultProject = p.Name
+	}
+	cliConfig.Projects = append(cliConfig.Projects, p)
+
+	// save config
+	if err = cliConfig.PersistIfNeeded(); err != nil {
+		return err
+	}
+
+	fmt.Println("Added project", p.Name)
+
+	return nil
+}
+
+func listProjects(c *cli.Context) error {
+	if len(cliConfig.Projects) == 0 {
+		fmt.Println("No projects configured, use `livekit-cli project add` to add a new project.")
+		return nil
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeader([]string{"Name", "URL", "API Key", "Default"})
+	for _, p := range cliConfig.Projects {
+		table.Append([]string{p.Name, p.URL, p.APIKey, fmt.Sprint(p.Name == cliConfig.DefaultProject)})
+	}
+	table.Render()
+	return nil
+}
+
+func removeProject(c *cli.Context) error {
+	if c.NArg() == 0 {
+		return errors.New("project name is required")
+	}
+	name := c.Args().First()
+
+	var newProjects []config.ProjectConfig
+	for _, p := range cliConfig.Projects {
+		if p.Name == name {
+			continue
+		}
+		newProjects = append(newProjects, p)
+	}
+	cliConfig.Projects = newProjects
+
+	if cliConfig.DefaultProject == name {
+		cliConfig.DefaultProject = ""
+	}
+
+	if err := cliConfig.PersistIfNeeded(); err != nil {
+		return err
+	}
+
+	fmt.Println("Removed project", name)
+
+	return nil
+}
+
+func setDefaultProject(c *cli.Context) error {
+	if c.NArg() == 0 {
+		return errors.New("project name is required")
+	}
+	name := c.Args().First()
+
+	for _, p := range cliConfig.Projects {
+		if p.Name == name {
+			cliConfig.DefaultProject = name
+			if err := cliConfig.PersistIfNeeded(); err != nil {
+				return err
+			}
+			fmt.Println("Default project set to", name)
+			return nil
+		}
+	}
+
+	return errors.New("project not found")
+}

--- a/cmd/livekit-cli/utils.go
+++ b/cmd/livekit-cli/utils.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/ggwhite/go-masker"
 	"github.com/urfave/cli/v2"
+
+	"github.com/livekit/livekit-cli/pkg/config"
 )
 
 var (
@@ -23,25 +27,37 @@ var (
 		Value:   "http://localhost:7880",
 	}
 	apiKeyFlag = &cli.StringFlag{
-		Name:     "api-key",
-		EnvVars:  []string{"LIVEKIT_API_KEY"},
-		Required: true,
+		Name:    "api-key",
+		EnvVars: []string{"LIVEKIT_API_KEY"},
 	}
 	secretFlag = &cli.StringFlag{
-		Name:     "api-secret",
-		EnvVars:  []string{"LIVEKIT_API_SECRET"},
-		Required: true,
+		Name:    "api-secret",
+		EnvVars: []string{"LIVEKIT_API_SECRET"},
 	}
 	identityFlag = &cli.StringFlag{
 		Name:     "identity",
 		Usage:    "identity of participant",
 		Required: true,
 	}
+	projectFlag = &cli.StringFlag{
+		Name:  "project",
+		Usage: "name of a configured project",
+	}
 	verboseFlag = &cli.BoolFlag{
 		Name:     "verbose",
 		Required: false,
 	}
 )
+
+func withDefaultFlags(flags ...cli.Flag) []cli.Flag {
+	return append([]cli.Flag{
+		urlFlag,
+		apiKeyFlag,
+		secretFlag,
+		projectFlag,
+		verboseFlag,
+	}, flags...)
+}
 
 func PrintJSON(obj interface{}) {
 	txt, _ := json.MarshalIndent(obj, "", "  ")
@@ -55,4 +71,91 @@ func ExpandUser(p string) string {
 	}
 
 	return p
+}
+
+type loadParams struct {
+	requireURL bool
+}
+
+type loadOption func(*loadParams)
+
+var ignoreURL = func(p *loadParams) {
+	p.requireURL = false
+}
+
+// attempt to load connection config, it'll prioritize
+// 1. command line flags (or env var)
+// 2. default project config
+func loadProjectDetails(c *cli.Context, opts ...loadOption) (*config.ProjectConfig, error) {
+	p := loadParams{requireURL: true}
+	for _, opt := range opts {
+		opt(&p)
+	}
+	logDetails := func(c *cli.Context, pc *config.ProjectConfig) {
+		if c.Bool("verbose") {
+			fmt.Printf("URL: %s, api-key: %s, api-secret: %s\n",
+				pc.URL,
+				pc.APIKey,
+				masker.ID(pc.APISecret))
+		}
+
+	}
+	pc := &config.ProjectConfig{}
+	if val := c.String("url"); val != "" {
+		pc.URL = val
+	}
+	if val := c.String("api-key"); val != "" {
+		pc.APIKey = val
+	}
+	if val := c.String("api-secret"); val != "" {
+		pc.APISecret = val
+	}
+	if pc.APIKey != "" && pc.APISecret != "" && (pc.URL != "" || !p.requireURL) {
+		var envVars []string
+		// if it's set via env, we should let users know
+		if os.Getenv("LIVEKIT_URL") == pc.URL {
+			envVars = append(envVars, "url")
+		}
+		if os.Getenv("LIVEKIT_API_KEY") == pc.APIKey {
+			envVars = append(envVars, "api-key")
+		}
+		if os.Getenv("LIVEKIT_API_SECRET") == pc.APISecret {
+			envVars = append(envVars, "api-secret")
+		}
+		if len(envVars) > 0 {
+			fmt.Printf("Using %s from environment\n", strings.Join(envVars, ", "))
+			logDetails(c, pc)
+		}
+		return pc, nil
+	}
+
+	if c.String("project") != "" {
+		pc, err := config.LoadProject(c.String("project"))
+		if err != nil {
+			return nil, err
+		}
+		logDetails(c, pc)
+		return pc, nil
+	}
+
+	// load from defaults
+	dp, err := config.LoadDefaultProject()
+	if err == nil {
+		fmt.Println("Using default project", dp.Name)
+		logDetails(c, dp)
+		return dp, nil
+	}
+
+	if p.requireURL && pc.URL == "" {
+		return nil, errors.New("url is required")
+	}
+	if pc.APIKey == "" {
+		return nil, errors.New("api-key is required")
+	}
+	if pc.APISecret == "" {
+		return nil, errors.New("api-secret is required")
+	}
+
+	// cannot happen
+	return pc, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-logr/stdr v1.2.2
 	github.com/livekit/protocol v1.0.2-0.20220817073830-613285ea6f32
 	github.com/livekit/server-sdk-go v0.10.5
+	github.com/manifoldco/promptui v0.9.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pion/rtp v1.7.13
 	github.com/pion/webrtc/v3 v3.1.43
@@ -18,12 +19,14 @@ require (
 	go.uber.org/atomic v1.10.0
 	golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde
 	google.golang.org/protobuf v1.28.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bep/debounce v1.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
@@ -60,7 +63,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	github.com/rogpeppe/go-internal v1.6.1 // indirect
+	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/thoas/go-funk v0.9.2 // indirect
 	github.com/twitchtv/twirp v8.1.2+incompatible // indirect
@@ -74,5 +77,4 @@ require (
 	google.golang.org/genproto v0.0.0-20220712132514-bdd2acd4974d // indirect
 	google.golang.org/grpc v1.48.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,11 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -208,6 +211,8 @@ github.com/livekit/server-sdk-go v0.10.5 h1:Qlh/+ZogcKAGxAqy7NaBZQ5a+F8U4JV8QaFv
 github.com/livekit/server-sdk-go v0.10.5/go.mod h1:crCNBg2wJ8SNIjUyseaGoUNha3HqeoQHxZ2GMT2mJkw=
 github.com/magefile/mage v1.13.0 h1:XtLJl8bcCM7EFoO8FyH8XK3t7G5hQAeK+i4tq+veT9M=
 github.com/magefile/mage v1.13.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
+github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
@@ -283,6 +288,7 @@ github.com/pion/webrtc/v3 v3.1.43 h1:YT3ZTO94UT4kSBvZnRAH82+0jJPUruiKr9CEstdlQzk
 github.com/pion/webrtc/v3 v3.1.43/go.mod h1:G/J8k0+grVsjC/rjCZ24AKoCCxcFFODgh7zThNZGs0M=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -316,8 +322,9 @@ github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
+github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
@@ -485,6 +492,7 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+
+	"gopkg.in/yaml.v3"
+)
+
+type CLIConfig struct {
+	DefaultProject string          `yaml:"default_project"`
+	Projects       []ProjectConfig `yaml:"projects"`
+	// absent from YAML
+	hasPersisted bool
+}
+
+type ProjectConfig struct {
+	Name      string `yaml:"name"`
+	URL       string `yaml:"url"`
+	APIKey    string `yaml:"api_key"`
+	APISecret string `yaml:"api_secret"`
+}
+
+func LoadDefaultProject() (*ProjectConfig, error) {
+	conf, err := LoadOrCreate()
+	if err != nil {
+		return nil, err
+	}
+
+	// prefer default project
+	if conf.DefaultProject != "" {
+		for _, p := range conf.Projects {
+			if p.Name == conf.DefaultProject {
+				return &p, nil
+			}
+		}
+	}
+
+	return nil, errors.New("no default project set")
+}
+
+func LoadProject(name string) (*ProjectConfig, error) {
+	conf, err := LoadOrCreate()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, p := range conf.Projects {
+		if p.Name == name {
+			return &p, nil
+		}
+	}
+
+	return nil, errors.New("project not found")
+}
+
+// LoadOrCreate loads config file from ~/.livekit/cli-config.yaml
+// if it doesn't exist, it'll return an empty config file
+func LoadOrCreate() (*CLIConfig, error) {
+	configPath, err := getConfigLocation()
+	if err != nil {
+		return nil, err
+	}
+
+	c := &CLIConfig{}
+	if s, err := os.Stat(configPath); os.IsNotExist(err) {
+		return c, nil
+	} else if err != nil {
+		return nil, err
+	} else if s.Mode().Perm()&0077 != 0 {
+		return nil, fmt.Errorf("config file %s should be 0600", configPath)
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	err = yaml.Unmarshal(content, c)
+	if err != nil {
+		return nil, err
+	}
+	c.hasPersisted = true
+
+	return c, nil
+}
+
+func (c *CLIConfig) PersistIfNeeded() error {
+	if len(c.Projects) == 0 && !c.hasPersisted {
+		// doesn't need to be persisted
+		return nil
+	}
+
+	configPath, err := getConfigLocation()
+	if err != nil {
+		return err
+	}
+	if err = os.MkdirAll(path.Dir(configPath), 0700); err != nil {
+		return err
+	}
+
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	if err = os.WriteFile(configPath, data, 0600); err != nil {
+		return err
+	}
+	fmt.Println("Saved CLI config to", configPath)
+	return nil
+}
+
+func getConfigLocation() (string, error) {
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return path.Join(dir, ".livekit", "cli-config.yaml"), nil
+}


### PR DESCRIPTION
Instead of having to pass in connection details or rely on a fixed set of environment variables, the project subcommand would save multiple connetion details in ~/.livekit/cli-config.yaml.

The design of the CLI takes inspiration from kubectl, where all commands are able to take in a `--project` flag and automatically use details from that project.

listing projects
```
% ./bin/livekit-cli project list
+------------+-----------------------------+--------------------------+---------+
|    NAME    |             URL             |         API KEY          | DEFAULT |
+------------+-----------------------------+--------------------------+---------+
| my-server  | https://my-server.host.com  | API012348rquKztZEoZJVabc | true    |
| local      | http://localhost:7880       | devkey                   | false   |
+------------+-----------------------------+--------------------------+---------+
```

adding project
```
% ./bin/livekit-cli project add 
Enter project details
✔ URL: http://myhost.com█
✗ API Key: █
```

setting as default
```
% ./bin/livekit-cli project set-default local
Saved CLI config to /Users/davidzhao/.livekit/cli-config.yaml
Default project set to local
```
```