### PR TITLE
don't assume uname in /usr/bin/

### DIFF
--- a/install-cli.sh
+++ b/install-cli.sh
@@ -62,7 +62,7 @@ then
   abort "Installer is only supported on Linux."
 fi
 
-ARCH="$(/usr/bin/uname -m)"
+ARCH="$(uname -m)"
 
 # fix arch on linux
 if [[ "${ARCH}" == "aarch64" ]]


### PR DESCRIPTION
uname exists in /bin on Ubuntu.  As such, the installation fails.               
                                                                                
The script determines the OS without specifying the complete path to uname.  Do  the same in order to determine ARCH.