### PR TITLE
Fix stale room name in load test

### DIFF
--- a/pkg/loadtester/loadtest.go
+++ b/pkg/loadtester/loadtest.go
@@ -218,7 +218,7 @@ func (t *LoadTest) run(params Params) (map[string]*testerStats, error) {
 		participantStrings = append(participantStrings, fmt.Sprintf("%d subscribers", t.Params.Subscribers))
 	}
 	fmt.Printf("Starting load test with %s, room: %s\n",
-		strings.Join(participantStrings, ", "), t.Params.Room)
+		strings.Join(participantStrings, ", "), params.Room)
 
 	testers := make([]*LoadTester, 0)
 	group, _ := errgroup.WithContext(t.Params.Context)


### PR DESCRIPTION
Previously, a generated random room name hasn't been printed. This small change fixes that.

**Before**
```
$ livekit-cli load-test --audio-publishers 32 --subscribers 32 [skipped connection params]
Starting load test with 32 audio publishers, 32 subscribers, room: 
publishing audio track - domji_pub_0
```

**After**
```
$ livekit-cli load-test --audio-publishers 32 --subscribers 32 [skipped connection params]
Starting load test with 32 audio publishers, 32 subscribers, room: testroom405
publishing audio track - sqksj_pub_0
```