### PR TITLE
Simulate rotating speakers with load-test and test-egress-template

### DIFF
--- a/cmd/livekit-cli/egress.go
+++ b/cmd/livekit-cli/egress.go
@@ -414,8 +414,15 @@ func testEgressTemplate(c *cli.Context) error {
 		return err
 	}
 
+	sim := loadtester.NewSpeakerSimulator(loadtester.SpeakerSimulatorParams{
+		Testers: testers,
+	})
+	sim.Start()
+	fmt.Println("simulating speakers...")
+
 	<-done
 
+	sim.Stop()
 	for _, lt := range testers {
 		lt.Stop()
 	}

--- a/cmd/livekit-cli/loadtest.go
+++ b/cmd/livekit-cli/loadtest.go
@@ -72,6 +72,10 @@ var LoadTestCommands = []*cli.Command{
 				Usage: "disables simulcast publishing (simulcast is enabled by default)",
 			},
 			&cli.BoolFlag{
+				Name:  "simulate-speakers",
+				Usage: "fire random speaker events to simulate speaker changes",
+			},
+			&cli.BoolFlag{
 				Name:   "run-all",
 				Usage:  "runs set list of load test cases",
 				Hidden: true,
@@ -100,11 +104,12 @@ func loadTest(cCtx *cli.Context) error {
 	}()
 
 	params := loadtester.Params{
-		VideoResolution: cCtx.String("video-resolution"),
-		VideoCodec:      cCtx.String("video-codec"),
-		Duration:        cCtx.Duration("duration"),
-		NumPerSecond:    cCtx.Float64("num-per-second"),
-		Simulcast:       !cCtx.Bool("no-simulcast"),
+		VideoResolution:  cCtx.String("video-resolution"),
+		VideoCodec:       cCtx.String("video-codec"),
+		Duration:         cCtx.Duration("duration"),
+		NumPerSecond:     cCtx.Float64("num-per-second"),
+		Simulcast:        !cCtx.Bool("no-simulcast"),
+		SimulateSpeakers: cCtx.Bool("simulate-speakers"),
 		TesterParams: loadtester.TesterParams{
 			URL:            pc.URL,
 			APIKey:         pc.APIKey,

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/livekit/livekit-cli
 go 1.18
 
 require (
+	github.com/frostbyte73/core v0.0.5
 	github.com/ggwhite/go-masker v1.0.9
 	github.com/go-logr/logr v1.2.4
 	github.com/livekit/protocol v1.5.1
@@ -31,7 +32,6 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/eapache/channels v1.1.0 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
-	github.com/frostbyte73/core v0.0.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/frostbyte73/core v0.0.4 h1:CwwoYfKPdNSO/QbOOMWMRSYoNW14ov4XHnt094AuMX8=
-github.com/frostbyte73/core v0.0.4/go.mod h1:mqHHSVFS5DE6kSdhU1/s9Mm0YCnLB8Ou2DD/eX1Zbr4=
+github.com/frostbyte73/core v0.0.5 h1:+oHjXDyQyQzEx04mtmmafYP07n7EToKpUGafWbNVQ9I=
+github.com/frostbyte73/core v0.0.5/go.mod h1:mqHHSVFS5DE6kSdhU1/s9Mm0YCnLB8Ou2DD/eX1Zbr4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ggwhite/go-masker v1.0.9 h1:9mKJzhLwJN1E5ekqNMk2ppP9ntWubIGtrUNV9wRouZo=

--- a/pkg/loadtester/loadtester.go
+++ b/pkg/loadtester/loadtester.go
@@ -254,6 +254,9 @@ func (t *LoadTester) Stop() {
 }
 
 func (t *LoadTester) numToSubscribe() int {
+	if !t.params.Subscribe {
+		return 0
+	}
 	switch t.params.Layout {
 	case LayoutSpeaker:
 		return 6

--- a/pkg/loadtester/speakersimulator.go
+++ b/pkg/loadtester/speakersimulator.go
@@ -1,0 +1,61 @@
+package loadtester
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/frostbyte73/core"
+
+	lksdk "github.com/livekit/server-sdk-go"
+)
+
+type SpeakerSimulatorParams struct {
+	Testers []*LoadTester
+	// amount of time between each speaker
+	Pause uint64
+}
+
+type SpeakerSimulator struct {
+	params SpeakerSimulatorParams
+	fuse   core.Fuse
+}
+
+func NewSpeakerSimulator(params SpeakerSimulatorParams) *SpeakerSimulator {
+	if params.Pause == 0 {
+		params.Pause = 1
+	}
+	return &SpeakerSimulator{
+		params: params,
+	}
+}
+
+func (s *SpeakerSimulator) Start() {
+	if s.fuse != nil {
+		return
+	}
+	s.fuse = core.NewFuse()
+	go s.worker()
+}
+
+func (s *SpeakerSimulator) Stop() {
+	if s.fuse == nil || s.fuse.IsBroken() {
+		return
+	}
+	s.fuse.Break()
+	s.fuse = nil
+}
+
+func (s *SpeakerSimulator) worker() {
+	t := time.NewTicker(time.Duration(s.params.Pause) * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-s.fuse.Watch():
+			return
+		case <-t.C:
+			speaker := s.params.Testers[rand.Intn(len(s.params.Testers))]
+			speaker.room.Simulate(lksdk.SimulateSpeakerUpdate)
+			t.Reset(time.Duration(s.params.Pause+lksdk.SimulateSpeakerUpdateInterval) * time.Second)
+		}
+	}
+}


### PR DESCRIPTION
`load-test` now takes in a `--simulate-speakers` flag to randomly rotate publishers to speak