### PR TITLE
Update git command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Download the [latest release here](https://github.com/livekit/livekit-cli/releas
 This repo uses [Git LFS](https://git-lfs.github.com/) for embedded video resources. Please ensure git-lfs is installed on your machine.
 
 ```shell
-git clone github.com/livekit/livekit-cli
+git clone https://github.com/livekit/livekit-cli
 make install
 ```
 


### PR DESCRIPTION
This is a super small docs PR: When running the current git command, the result is `fatal: repository 'github.com/livekit/livekit-cli' does not exist`. I've followed the example from https://github.com/livekit/livekit/blob/master/README.md#building-from-source and added the `https://` prefix.


