### PR TITLE
goreleaser: improve binary artifact size

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,6 +30,8 @@ builds:
     goos:
       - linux
       - windows
+    ldflags:
+      - -s -w
 archives:
   - format_overrides:
       - goos: windows


### PR DESCRIPTION
update ldflags to include `-s -w` to strip the symbol table and DWARF debug information.

cc @Sean-Der 