### PR TITLE
Fix: Correct sudo usage during installation

### DIFF
--- a/install-cli.sh
+++ b/install-cli.sh
@@ -101,9 +101,9 @@ log "Downloading from ${ARCHIVE_URL}..."
 
 TEMP_DIR_PATH="$(mktemp -d)"
 
-curl -s -L "${ARCHIVE_URL}" | ${SUDO_PREFIX} tar xzf - -C "${TEMP_DIR_PATH}" --wildcards --no-anchored "$REPO*"
+curl -s -L "${ARCHIVE_URL}" | tar xzf - -C "${TEMP_DIR_PATH}" --wildcards --no-anchored "$REPO*"
 
-mv "${TEMP_DIR_PATH}/livekit-cli" "${INSTALL_PATH}/livekit-cli"
+${SUDO_PREFIX} mv "${TEMP_DIR_PATH}/livekit-cli" "${INSTALL_PATH}/livekit-cli"
 
 if [ -d "${TEMP_DIR_PATH}/autocomplete" ]
 then


### PR DESCRIPTION
sudo should be called when moving the file, not when unarchiving. 

- fixes #324  
- fixes #327

verified to work. here's the output:
```
󰘎  bash install-cli.sh
sudo is required to install to /usr/local/bin
Installing livekit-cli 1.4.3
Downloading from https://github.com/livekit/livekit-cli/releases/download/v1.4.3/livekit-cli_1.4.3_linux_amd64.tar.gz...
[sudo] password for esskayesss:

livekit-cli is installed to /usr/local/bin
```