### PR TITLE
Support new SIP Trunk API. Move to subcommands.

### DIFF
--- a/cmd/livekit-cli/proto.go
+++ b/cmd/livekit-cli/proto.go
@@ -1,0 +1,55 @@
+// Copyright 2024 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"reflect"
+
+	"github.com/urfave/cli/v2"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+const flagRequest = "request"
+
+func ReadRequest[T any, P interface {
+	*T
+	proto.Message
+}](c *cli.Context) (*T, error) {
+	reqBytes, err := os.ReadFile(c.String(flagRequest))
+	if err != nil {
+		return nil, err
+	}
+
+	var req P = new(T)
+	err = protojson.Unmarshal(reqBytes, req)
+	if err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
+func RequestFlag[T any, _ interface {
+	*T
+	proto.Message
+}]() *cli.StringFlag {
+	typ := reflect.TypeFor[T]().Name()
+	return &cli.StringFlag{
+		Name:     flagRequest,
+		Usage:    typ + " as JSON file (see livekit-cli/examples)",
+		Required: true,
+	}
+}

--- a/cmd/livekit-cli/sip.go
+++ b/cmd/livekit-cli/sip.go
@@ -17,20 +17,23 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/livekit/protocol/livekit"
 	lksdk "github.com/livekit/server-sdk-go/v2"
-	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v2"
 )
 
 //lint:file-ignore SA1019 we still support older APIs for compatibility
 
-const sipCategory = "SIP"
+const (
+	sipCategory            = "SIP"
+	sipTrunkCategory       = "Trunks"
+	sipDispatchCategory    = "Dispatch Rules"
+	sipParticipantCategory = "Participants"
+)
 
 var (
 	SIPCommands = []*cli.Command{
@@ -43,39 +46,29 @@ var (
 					Name:     "inbound",
 					Aliases:  []string{"in", "inbound-trunk"},
 					Usage:    "Inbound SIP Trunk management",
-					Category: sipCategory,
+					Category: sipTrunkCategory,
 					Subcommands: []*cli.Command{
 						{
-							Name:     "list",
-							Usage:    "List all inbound SIP Trunk",
-							Before:   createSIPClient,
-							Action:   listSipInboundTrunk,
-							Category: sipCategory,
-							Flags:    withDefaultFlags(),
+							Name:   "list",
+							Usage:  "List all inbound SIP Trunk",
+							Action: listSipInboundTrunk,
+							Flags:  withDefaultFlags(),
 						},
 						{
-							Name:     "create",
-							Usage:    "Create a inbound SIP Trunk",
-							Before:   createSIPClient,
-							Action:   createSIPInboundTrunk,
-							Category: sipCategory,
-							Flags: withDefaultFlags(
-								RequestFlag[livekit.CreateSIPInboundTrunkRequest](),
-							),
+							Name:      "create",
+							Usage:     "Create a inbound SIP Trunk",
+							Action:    createSIPInboundTrunk,
+							Flags:     withDefaultFlags(),
+							Args:      true,
+							ArgsUsage: RequestDesc[livekit.CreateSIPInboundTrunkRequest](),
 						},
 						{
-							Name:     "delete",
-							Usage:    "Delete inbound SIP Trunk",
-							Before:   createSIPClient,
-							Action:   deleteSIPTrunk,
-							Category: sipCategory,
-							Flags: withDefaultFlags(
-								&cli.StringFlag{
-									Name:     "id",
-									Usage:    "SIPTrunk ID",
-									Required: true,
-								},
-							),
+							Name:      "delete",
+							Usage:     "Delete SIP Trunk",
+							Action:    deleteSIPTrunk,
+							Flags:     withDefaultFlags(),
+							Args:      true,
+							ArgsUsage: "SIPTrunk ID to delete",
 						},
 					},
 				},
@@ -83,39 +76,29 @@ var (
 					Name:     "outbound",
 					Aliases:  []string{"out", "outbound-trunk"},
 					Usage:    "Outbound SIP Trunk management",
-					Category: sipCategory,
+					Category: sipTrunkCategory,
 					Subcommands: []*cli.Command{
 						{
-							Name:     "list",
-							Usage:    "List all outbound SIP Trunk",
-							Before:   createSIPClient,
-							Action:   listSipOutboundTrunk,
-							Category: sipCategory,
-							Flags:    withDefaultFlags(),
+							Name:   "list",
+							Usage:  "List all outbound SIP Trunk",
+							Action: listSipOutboundTrunk,
+							Flags:  withDefaultFlags(),
 						},
 						{
-							Name:     "create",
-							Usage:    "Create a outbound SIP Trunk",
-							Before:   createSIPClient,
-							Action:   createSIPOutboundTrunk,
-							Category: sipCategory,
-							Flags: withDefaultFlags(
-								RequestFlag[livekit.CreateSIPOutboundTrunkRequest](),
-							),
+							Name:      "create",
+							Usage:     "Create a outbound SIP Trunk",
+							Action:    createSIPOutboundTrunk,
+							Flags:     withDefaultFlags(),
+							Args:      true,
+							ArgsUsage: RequestDesc[livekit.CreateSIPOutboundTrunkRequest](),
 						},
 						{
-							Name:     "delete",
-							Usage:    "Delete outbound SIP Trunk",
-							Before:   createSIPClient,
-							Action:   deleteSIPTrunk,
-							Category: sipCategory,
-							Flags: withDefaultFlags(
-								&cli.StringFlag{
-									Name:     "id",
-									Usage:    "SIPTrunk ID",
-									Required: true,
-								},
-							),
+							Name:      "delete",
+							Usage:     "Delete SIP Trunk",
+							Action:    deleteSIPTrunk,
+							Flags:     withDefaultFlags(),
+							Args:      true,
+							ArgsUsage: "SIPTrunk ID to delete",
 						},
 					},
 				},
@@ -123,56 +106,44 @@ var (
 					Name:     "dispatch",
 					Usage:    "SIP Dispatch Rule management",
 					Aliases:  []string{"dispatch-rule"},
-					Category: sipCategory,
+					Category: sipDispatchCategory,
 					Subcommands: []*cli.Command{
 						{
-							Name:     "create",
-							Usage:    "Create a SIP Dispatch Rule",
-							Before:   createSIPClient,
-							Action:   createSIPDispatchRule,
-							Category: sipCategory,
-							Flags: withDefaultFlags(
-								RequestFlag[livekit.CreateSIPDispatchRuleRequest](),
-							),
+							Name:   "list",
+							Usage:  "List all SIP Dispatch Rule",
+							Action: listSipDispatchRule,
+							Flags:  withDefaultFlags(),
 						},
 						{
-							Name:     "list",
-							Usage:    "List all SIP Dispatch Rule",
-							Before:   createSIPClient,
-							Action:   listSipDispatchRule,
-							Category: sipCategory,
-							Flags:    withDefaultFlags(),
+							Name:      "create",
+							Usage:     "Create a SIP Dispatch Rule",
+							Action:    createSIPDispatchRule,
+							Flags:     withDefaultFlags(),
+							Args:      true,
+							ArgsUsage: RequestDesc[livekit.CreateSIPDispatchRuleRequest](),
 						},
 						{
-							Name:     "delete",
-							Usage:    "Delete SIP Dispatch Rule",
-							Before:   createSIPClient,
-							Action:   deleteSIPDispatchRule,
-							Category: sipCategory,
-							Flags: withDefaultFlags(
-								&cli.StringFlag{
-									Name:     "id",
-									Usage:    "SIPDispatchRule ID",
-									Required: true,
-								},
-							),
+							Name:      "delete",
+							Usage:     "Delete SIP Dispatch Rule",
+							Action:    deleteSIPDispatchRule,
+							Flags:     withDefaultFlags(),
+							Args:      true,
+							ArgsUsage: "SIPTrunk ID to delete",
 						},
 					},
 				},
 				{
 					Name:     "participant",
 					Usage:    "SIP Participant management",
-					Category: sipCategory,
+					Category: sipParticipantCategory,
 					Subcommands: []*cli.Command{
 						{
-							Name:     "create",
-							Usage:    "Create a SIP Participant",
-							Before:   createSIPClient,
-							Action:   createSIPParticipant,
-							Category: sipCategory,
-							Flags: withDefaultFlags(
-								RequestFlag[livekit.CreateSIPParticipantRequest](),
-							),
+							Name:      "create",
+							Usage:     "Create a SIP Participant",
+							Action:    createSIPParticipant,
+							Flags:     withDefaultFlags(),
+							Args:      true,
+							ArgsUsage: RequestDesc[livekit.CreateSIPParticipantRequest](),
 						},
 					},
 				},
@@ -184,8 +155,7 @@ var (
 			Hidden:   true, // deprecated: use "sip trunk create"
 			Name:     "create-sip-trunk",
 			Usage:    "Create a SIP Trunk",
-			Before:   createSIPClient,
-			Action:   createSIPTrunk,
+			Action:   createSIPTrunkLegacy,
 			Category: sipCategory,
 			Flags: withDefaultFlags(
 				//lint:ignore SA1019 we still support it
@@ -196,7 +166,6 @@ var (
 			Hidden:   true, // deprecated: use "sip trunk list"
 			Name:     "list-sip-trunk",
 			Usage:    "List all SIP trunk",
-			Before:   createSIPClient,
 			Action:   listSipTrunk,
 			Category: sipCategory,
 			Flags:    withDefaultFlags(),
@@ -205,8 +174,7 @@ var (
 			Hidden:   true, // deprecated: use "sip trunk delete"
 			Name:     "delete-sip-trunk",
 			Usage:    "Delete SIP Trunk",
-			Before:   createSIPClient,
-			Action:   deleteSIPTrunk,
+			Action:   deleteSIPTrunkLegacy,
 			Category: sipCategory,
 			Flags: withDefaultFlags(
 				&cli.StringFlag{
@@ -220,8 +188,7 @@ var (
 			Hidden:   true, // deprecated: use "sip dispatch create"
 			Name:     "create-sip-dispatch-rule",
 			Usage:    "Create a SIP Dispatch Rule",
-			Before:   createSIPClient,
-			Action:   createSIPDispatchRule,
+			Action:   createSIPDispatchRuleLegacy,
 			Category: sipCategory,
 			Flags: withDefaultFlags(
 				RequestFlag[livekit.CreateSIPDispatchRuleRequest](),
@@ -231,7 +198,6 @@ var (
 			Hidden:   true, // deprecated: use "sip dispatch list"
 			Name:     "list-sip-dispatch-rule",
 			Usage:    "List all SIP Dispatch Rule",
-			Before:   createSIPClient,
 			Action:   listSipDispatchRule,
 			Category: sipCategory,
 			Flags:    withDefaultFlags(),
@@ -240,8 +206,7 @@ var (
 			Hidden:   true, // deprecated: use "sip dispatch delete"
 			Name:     "delete-sip-dispatch-rule",
 			Usage:    "Delete SIP Dispatch Rule",
-			Before:   createSIPClient,
-			Action:   deleteSIPDispatchRule,
+			Action:   deleteSIPDispatchRuleLegacy,
 			Category: sipCategory,
 			Flags: withDefaultFlags(
 				&cli.StringFlag{
@@ -255,85 +220,46 @@ var (
 			Hidden:   true, // deprecated: use "sip participant create"
 			Name:     "create-sip-participant",
 			Usage:    "Create a SIP Participant",
-			Before:   createSIPClient,
-			Action:   createSIPParticipant,
+			Action:   createSIPParticipantLegacy,
 			Category: sipCategory,
 			Flags: withDefaultFlags(
 				RequestFlag[livekit.CreateSIPParticipantRequest](),
 			),
 		},
 	}
-
-	sipClient *lksdk.SIPClient
 )
 
-func createSIPClient(c *cli.Context) error {
+func createSIPClient(c *cli.Context) (*lksdk.SIPClient, error) {
 	pc, err := loadProjectDetails(c)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	sipClient = lksdk.NewSIPClient(pc.URL, pc.APIKey, pc.APISecret, withDefaultClientOpts(pc)...)
-	return nil
+	return lksdk.NewSIPClient(pc.URL, pc.APIKey, pc.APISecret, withDefaultClientOpts(pc)...), nil
 }
 
-func createSIPTrunk(c *cli.Context) error {
-	//lint:ignore SA1019 we still support it
-	req, err := ReadRequest[livekit.CreateSIPTrunkRequest](c)
+func createSIPTrunkLegacy(c *cli.Context) error {
+	cli, err := createSIPClient(c)
 	if err != nil {
 		return err
 	}
-
-	if c.Bool("verbose") {
-		PrintJSON(req)
-	}
-
 	//lint:ignore SA1019 we still support it
-	info, err := sipClient.CreateSIPTrunk(c.Context, req)
-	if err != nil {
-		return err
-	}
-
-	printSIPTrunkID(info)
-	return nil
+	return createAndPrintLegacy(c, cli.CreateSIPTrunk, printSIPTrunkID)
 }
 
 func createSIPInboundTrunk(c *cli.Context) error {
-	req, err := ReadRequest[livekit.CreateSIPInboundTrunkRequest](c)
+	cli, err := createSIPClient(c)
 	if err != nil {
 		return err
 	}
-
-	if c.Bool("verbose") {
-		PrintJSON(req)
-	}
-
-	info, err := sipClient.CreateSIPInboundTrunk(c.Context, req)
-	if err != nil {
-		return err
-	}
-
-	printSIPTrunkID(info)
-	return nil
+	return createAndPrintReqs(c, cli.CreateSIPInboundTrunk, printSIPInboundTrunkID)
 }
 
 func createSIPOutboundTrunk(c *cli.Context) error {
-	req, err := ReadRequest[livekit.CreateSIPOutboundTrunkRequest](c)
+	cli, err := createSIPClient(c)
 	if err != nil {
 		return err
 	}
-
-	if c.Bool("verbose") {
-		PrintJSON(req)
-	}
-
-	info, err := sipClient.CreateSIPOutboundTrunk(c.Context, req)
-	if err != nil {
-		return err
-	}
-
-	printSIPTrunkID(info)
-	return nil
+	return createAndPrintReqs(c, cli.CreateSIPOutboundTrunk, printSIPOutboundTrunkID)
 }
 
 func userPass(user string, hasPass bool) string {
@@ -348,159 +274,140 @@ func userPass(user string, hasPass bool) string {
 }
 
 func listSipTrunk(c *cli.Context) error {
-	//lint:ignore SA1019 we still support it
-	res, err := sipClient.ListSIPTrunk(c.Context, &livekit.ListSIPTrunkRequest{})
+	cli, err := createSIPClient(c)
 	if err != nil {
 		return err
 	}
-
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{
+	//lint:ignore SA1019 we still support it
+	return listAndPrint(c, cli.ListSIPTrunk, &livekit.ListSIPTrunkRequest{}, []string{
 		"SipTrunkId", "Name", "Kind", "Number",
 		"AllowAddresses", "AllowNumbers", "InboundAuth",
 		"OutboundAddress", "OutboundAuth",
 		"Metadata",
-	})
-	for _, item := range res.Items {
-		if item == nil {
-			continue
-		}
+	}, func(item *livekit.SIPTrunkInfo) []string {
 		inboundNumbers := item.InboundNumbers
 		for _, re := range item.InboundNumbersRegex {
 			inboundNumbers = append(inboundNumbers, "regexp("+re+")")
 		}
-
-		table.Append([]string{
+		return []string{
 			item.SipTrunkId, item.Name, strings.TrimPrefix(item.Kind.String(), "TRUNK_"), item.OutboundNumber,
 			strings.Join(item.InboundAddresses, ","), strings.Join(inboundNumbers, ","), userPass(item.InboundUsername, item.InboundPassword != ""),
 			item.OutboundAddress, userPass(item.OutboundUsername, item.OutboundPassword != ""),
 			item.Metadata,
-		})
-	}
-	table.Render()
-
-	if c.Bool("verbose") {
-		PrintJSON(res)
-	}
-
-	return nil
+		}
+	})
 }
 
 func listSipInboundTrunk(c *cli.Context) error {
-	res, err := sipClient.ListSIPInboundTrunk(c.Context, &livekit.ListSIPInboundTrunkRequest{})
+	cli, err := createSIPClient(c)
 	if err != nil {
 		return err
 	}
-
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{
+	return listAndPrint(c, cli.ListSIPInboundTrunk, &livekit.ListSIPInboundTrunkRequest{}, []string{
 		"SipTrunkId", "Name", "Numbers",
 		"AllowedAddresses", "AllowedNumbers",
 		"Authentication",
 		"Metadata",
-	})
-	for _, item := range res.Items {
-		if item == nil {
-			continue
-		}
-		table.Append([]string{
+	}, func(item *livekit.SIPInboundTrunkInfo) []string {
+		return []string{
 			item.SipTrunkId, item.Name, strings.Join(item.Numbers, ","),
 			strings.Join(item.AllowedAddresses, ","), strings.Join(item.AllowedNumbers, ","),
 			userPass(item.AuthUsername, item.AuthPassword != ""),
 			item.Metadata,
-		})
-	}
-	table.Render()
-
-	if c.Bool("verbose") {
-		PrintJSON(res)
-	}
-
-	return nil
+		}
+	})
 }
 
 func listSipOutboundTrunk(c *cli.Context) error {
-	res, err := sipClient.ListSIPOutboundTrunk(c.Context, &livekit.ListSIPOutboundTrunkRequest{})
+	cli, err := createSIPClient(c)
 	if err != nil {
 		return err
 	}
-
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{
+	return listAndPrint(c, cli.ListSIPOutboundTrunk, &livekit.ListSIPOutboundTrunkRequest{}, []string{
 		"SipTrunkId", "Name",
 		"Address", "Transport",
 		"Numbers",
 		"Authentication",
 		"Metadata",
-	})
-	for _, item := range res.Items {
-		if item == nil {
-			continue
-		}
-		table.Append([]string{
+	}, func(item *livekit.SIPOutboundTrunkInfo) []string {
+		return []string{
 			item.SipTrunkId, item.Name,
 			item.Address, strings.TrimPrefix(item.Transport.String(), "SIP_TRANSPORT_"),
 			strings.Join(item.Numbers, ","),
 			userPass(item.AuthUsername, item.AuthPassword != ""),
 			item.Metadata,
-		})
-	}
-	table.Render()
-
-	if c.Bool("verbose") {
-		PrintJSON(res)
-	}
-
-	return nil
+		}
+	})
 }
 
 func deleteSIPTrunk(c *cli.Context) error {
-	info, err := sipClient.DeleteSIPTrunk(c.Context, &livekit.DeleteSIPTrunkRequest{
+	cli, err := createSIPClient(c)
+	if err != nil {
+		return err
+	}
+	return forEachID(c, func(ctx context.Context, id string) error {
+		info, err := cli.DeleteSIPTrunk(c.Context, &livekit.DeleteSIPTrunkRequest{
+			SipTrunkId: id,
+		})
+		if err != nil {
+			return err
+		}
+		printSIPTrunkID(info)
+		return nil
+	})
+}
+
+func deleteSIPTrunkLegacy(c *cli.Context) error {
+	cli, err := createSIPClient(c)
+	if err != nil {
+		return err
+	}
+	info, err := cli.DeleteSIPTrunk(c.Context, &livekit.DeleteSIPTrunkRequest{
 		SipTrunkId: c.String("id"),
 	})
 	if err != nil {
 		return err
 	}
-
 	printSIPTrunkID(info)
 	return nil
 }
 
-func printSIPTrunkID(info interface{ GetSipTrunkId() string }) {
+func printSIPTrunkID(info *livekit.SIPTrunkInfo) {
+	fmt.Printf("SIPTrunkID: %v\n", info.GetSipTrunkId())
+}
+
+func printSIPInboundTrunkID(info *livekit.SIPInboundTrunkInfo) {
+	fmt.Printf("SIPTrunkID: %v\n", info.GetSipTrunkId())
+}
+
+func printSIPOutboundTrunkID(info *livekit.SIPOutboundTrunkInfo) {
 	fmt.Printf("SIPTrunkID: %v\n", info.GetSipTrunkId())
 }
 
 func createSIPDispatchRule(c *cli.Context) error {
-	req, err := ReadRequest[livekit.CreateSIPDispatchRuleRequest](c)
+	cli, err := createSIPClient(c)
 	if err != nil {
 		return err
 	}
+	return createAndPrintReqs(c, cli.CreateSIPDispatchRule, printSIPDispatchRuleID)
+}
 
-	if c.Bool("verbose") {
-		PrintJSON(req)
-	}
-
-	info, err := sipClient.CreateSIPDispatchRule(c.Context, req)
+func createSIPDispatchRuleLegacy(c *cli.Context) error {
+	cli, err := createSIPClient(c)
 	if err != nil {
 		return err
 	}
-
-	printSIPDispatchRuleID(info)
-	return nil
+	return createAndPrintLegacy(c, cli.CreateSIPDispatchRule, printSIPDispatchRuleID)
 }
 
 func listSipDispatchRule(c *cli.Context) error {
-	res, err := sipClient.ListSIPDispatchRule(c.Context, &livekit.ListSIPDispatchRuleRequest{})
+	cli, err := createSIPClient(c)
 	if err != nil {
 		return err
 	}
-
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"SipDispatchRuleId", "Name", "SipTrunks", "Type", "RoomName", "Pin", "HidePhone", "Metadata"})
-	for _, item := range res.Items {
-		if item == nil {
-			continue
-		}
+	return listAndPrint(c, cli.ListSIPDispatchRule, &livekit.ListSIPDispatchRuleRequest{}, []string{
+		"SipDispatchRuleId", "Name", "SipTrunks", "Type", "RoomName", "Pin", "HidePhone", "Metadata",
+	}, func(item *livekit.SIPDispatchRuleInfo) []string {
 		var room, typ, pin string
 		switch r := item.GetRule().GetRule().(type) {
 		case *livekit.SIPDispatchRule_DispatchRuleDirect:
@@ -516,25 +423,38 @@ func listSipDispatchRule(c *cli.Context) error {
 		if trunks == "" {
 			trunks = "<any>"
 		}
-		table.Append([]string{item.SipDispatchRuleId, item.Name, trunks, typ, room, pin, strconv.FormatBool(item.HidePhoneNumber), item.Metadata})
-	}
-	table.Render()
-
-	if c.Bool("verbose") {
-		PrintJSON(res)
-	}
-
-	return nil
+		return []string{item.SipDispatchRuleId, item.Name, trunks, typ, room, pin, strconv.FormatBool(item.HidePhoneNumber), item.Metadata}
+	})
 }
 
 func deleteSIPDispatchRule(c *cli.Context) error {
-	info, err := sipClient.DeleteSIPDispatchRule(c.Context, &livekit.DeleteSIPDispatchRuleRequest{
+	cli, err := createSIPClient(c)
+	if err != nil {
+		return err
+	}
+	return forEachID(c, func(ctx context.Context, id string) error {
+		info, err := cli.DeleteSIPDispatchRule(c.Context, &livekit.DeleteSIPDispatchRuleRequest{
+			SipDispatchRuleId: id,
+		})
+		if err != nil {
+			return err
+		}
+		printSIPDispatchRuleID(info)
+		return nil
+	})
+}
+
+func deleteSIPDispatchRuleLegacy(c *cli.Context) error {
+	cli, err := createSIPClient(c)
+	if err != nil {
+		return err
+	}
+	info, err := cli.DeleteSIPDispatchRule(c.Context, &livekit.DeleteSIPDispatchRuleRequest{
 		SipDispatchRuleId: c.String("id"),
 	})
 	if err != nil {
 		return err
 	}
-
 	printSIPDispatchRuleID(info)
 	return nil
 }
@@ -544,27 +464,33 @@ func printSIPDispatchRuleID(info *livekit.SIPDispatchRuleInfo) {
 }
 
 func createSIPParticipant(c *cli.Context) error {
-	req, err := ReadRequest[livekit.CreateSIPParticipantRequest](c)
+	cli, err := createSIPClient(c)
 	if err != nil {
 		return err
 	}
+	return createAndPrintReqs(c, func(ctx context.Context, req *livekit.CreateSIPParticipantRequest) (*livekit.SIPParticipantInfo, error) {
+		// CreateSIPParticipant will wait for LiveKit Participant to be created and that can take some time.
+		// Default deadline is too short, thus, we must set a higher deadline for it.
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
 
-	if c.Bool("verbose") {
-		PrintJSON(req)
-	}
+		return cli.CreateSIPParticipant(ctx, req)
+	}, printSIPParticipantInfo)
+}
 
-	// CreateSIPParticipant will wait for LiveKit Participant to be created and that can take some time.
-	// Default deadline is too short, thus, we must set a higher deadline for it.
-	ctx, cancel := context.WithTimeout(c.Context, 30*time.Second)
-	defer cancel()
-
-	info, err := sipClient.CreateSIPParticipant(ctx, req)
+func createSIPParticipantLegacy(c *cli.Context) error {
+	cli, err := createSIPClient(c)
 	if err != nil {
 		return err
 	}
+	return createAndPrintLegacy(c, func(ctx context.Context, req *livekit.CreateSIPParticipantRequest) (*livekit.SIPParticipantInfo, error) {
+		// CreateSIPParticipant will wait for LiveKit Participant to be created and that can take some time.
+		// Default deadline is too short, thus, we must set a higher deadline for it.
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
 
-	printSIPParticipantInfo(info)
-	return nil
+		return cli.CreateSIPParticipant(ctx, req)
+	}, printSIPParticipantInfo)
 }
 
 func printSIPParticipantInfo(info *livekit.SIPParticipantInfo) {

--- a/cmd/livekit-cli/utils.go
+++ b/cmd/livekit-cli/utils.go
@@ -96,7 +96,7 @@ func withDefaultClientOpts(c *config.ProjectConfig) []twirp.ClientOption {
 	return opts
 }
 
-func PrintJSON(obj interface{}) {
+func PrintJSON(obj any) {
 	txt, _ := json.MarshalIndent(obj, "", "  ")
 	fmt.Println(string(txt))
 }


### PR DESCRIPTION
Support new SIP Inbound/Outbound Trunk API and move all SIP commands into a separate cli tree:

- `list-sip-trunk` -> `sip trunk list`
- `list-sip-dispatch-rule` -> `sip dispatch list`
- `create-sip-participant` -> `sip participant create`

Old commands continue to work, they are only hidden from the CLI help.

I also renamed the columns for legacy trunks list command. Now they match names in new API (`OutboundNumber` -> `Number`, `InboundNumbers` -> `AllowedNumbers`). 

Requires https://github.com/livekit/protocol/pull/738