### PR TITLE
bump version for 1.5.1 release

### DIFF
--- a/version.go
+++ b/version.go
@@ -15,5 +15,5 @@
 package livekitcli
 
 const (
-	Version = "1.4.3"
+	Version = "1.5.0"
 )

--- a/version.go
+++ b/version.go
@@ -15,5 +15,5 @@
 package livekitcli
 
 const (
-	Version = "1.5.0"
+	Version = "1.5.1"
 )


### PR DESCRIPTION
patch to version to match with 1.5.0 release

relates to https://github.com/Homebrew/homebrew-core/pull/175433