### PR TITLE
fix(lk): correct cfg file permission check and bin name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,10 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 cli: check_lfs
-	go build -ldflags "-w -s" -o bin/lk ./cmd/lk
-	GOOS=linux GOARCH=amd64 go build -o bin/lk-linux ./cmd/lk
+	GOOS=darwin GOARCH=arm64 go build -ldflags "-w -s" -o bin/lk ./cmd/lk
+	GOOS=linux GOARCH=amd64 go build -ldflags "-w -s" -o bin/lk-linux ./cmd/lk
+	GOOS=windows GOARCH=amd64 go build -ldflags "-w -s" -o bin/lk.exe ./cmd/lk
+
 
 install: cli
 	cp bin/lk $(GOBIN)/

--- a/cmd/lk/main.go
+++ b/cmd/lk/main.go
@@ -101,7 +101,7 @@ func main() {
 }
 
 func checkForLegacyName() {
-	if !strings.HasSuffix(os.Args[0], "lk") {
+	if !(strings.HasSuffix(os.Args[0], "lk") || strings.HasSuffix(os.Args[0], "lk.exe")) {
 		fmt.Fprintf(
 			os.Stderr,
 			"\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ DEPRECATION NOTICE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"+

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -83,7 +83,9 @@ func LoadOrCreate() (*CLIConfig, error) {
 		return c, nil
 	} else if err != nil {
 		return nil, err
-	} else if s.Mode().Perm()&0600 != 0600 {
+		// because this file contains private keys, ensure
+		// that only the owner has permission to access it
+	} else if s.Mode().Perm()&0077 != 0 {
 		return nil, fmt.Errorf("config file %s should be 0600", configPath)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -83,7 +83,7 @@ func LoadOrCreate() (*CLIConfig, error) {
 		return c, nil
 	} else if err != nil {
 		return nil, err
-	} else if s.Mode().Perm()&0077 != 0 {
+	} else if s.Mode().Perm()&0600 != 0600 {
 		return nil, fmt.Errorf("config file %s should be 0600", configPath)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -83,10 +83,10 @@ func LoadOrCreate() (*CLIConfig, error) {
 		return c, nil
 	} else if err != nil {
 		return nil, err
-		// because this file contains private keys, ensure
-		// that only the owner has permission to access it
 	} else if s.Mode().Perm()&0077 != 0 {
-		return nil, fmt.Errorf("config file %s should be 0600", configPath)
+		// because this file contains private keys, warn that
+		// only the owner should have permission to access it
+		fmt.Fprintf(os.Stderr, "WARNING: config file %s should have permissions %o\n", configPath, 0600)
 	}
 
 	content, err := os.ReadFile(configPath)


### PR DESCRIPTION
- Fixes erroneous file permission check on config directory
- Explicit build targets to make it simpler to build in Windows
- Deprecation check is now aware of Windows executable name

https://linear.app/livekit/issue/CLT-560/cli-error-config-file-cusersgrafhlivekitcli-configyaml-should-be-0600