### PR TITLE
Send and receive DTMF in join command.

### DIFF
--- a/cmd/lk/join.go
+++ b/cmd/lk/join.go
@@ -30,10 +30,11 @@ import (
 	"github.com/pion/webrtc/v3"
 	"github.com/urfave/cli/v3"
 
-	provider2 "github.com/livekit/livekit-cli/pkg/provider"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
 	lksdk "github.com/livekit/server-sdk-go/v2"
+
+	provider2 "github.com/livekit/livekit-cli/pkg/provider"
 )
 
 var (


### PR DESCRIPTION
Switch to the new `OnDataPacket` callback instead of the legacy `OnDataReceived`. Add flags for publishing DTMF and user data to `lk room join`. Legacy `lk join-room` still uses old callback and doesn't support new flags.