### PR TITLE
Fix flags getting erroneously hidden or optional

### DIFF
--- a/cmd/lk/utils.go
+++ b/cmd/lk/utils.go
@@ -86,15 +86,15 @@ var (
 )
 
 func optional[T any, C any, VC cli.ValueCreator[T, C]](flag *cli.FlagBase[T, C, VC]) *cli.FlagBase[T, C, VC] {
-	newFlag := flag
+	newFlag := *flag
 	newFlag.Required = false
-	return newFlag
+	return &newFlag
 }
 
 func hidden[T any, C any, VC cli.ValueCreator[T, C]](flag *cli.FlagBase[T, C, VC]) *cli.FlagBase[T, C, VC] {
-	newFlag := flag
+	newFlag := *flag
 	newFlag.Hidden = true
-	return newFlag
+	return &newFlag
 }
 
 func withDefaultClientOpts(c *config.ProjectConfig) []twirp.ClientOption {


### PR DESCRIPTION
The optional/hidden functions modify the original flag passed in rather than create their own copy. This ends up displaying the wrong options in the help menu for a command. For example, `lk room send-data` requires the `--room` flag, but running help on the command gives this:

```
NAME:
   lk room send-data - Send arbitrary JSON data to client

USAGE:
   lk room send-data [OPTIONS] DATA

OPTIONS:
   --topic TOPIC                          TOPIC of the message
   --identity value [ --identity value ]  One or more participant identities to send the message to. When empty, broadcasts to the entire room
   --help, -h                             show help (default: false)
```

It also allows running the command itself, not raising that the `room` flag wasn't set.