### PR TITLE
chore(cmd): cleanup for sbx internal alpha

### DIFF
--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -326,6 +326,7 @@ func cloneTemplate(_ context.Context, cmd *cli.Command, url, appName string) err
 			}
 			os.RemoveAll(path.Join(appName, ".git"))
 		}).
+		Style(theme.Focused.Title).
 		Run(); err != nil {
 		return err
 	}
@@ -384,7 +385,7 @@ func doInstall(ctx context.Context, task bootstrap.KnownTask, rootPath string, v
 		if err := spinner.New().
 			Title("Installing...").
 			Action(func() { cmdErr = install() }).
-			Type(spinner.Dots).
+			Style(theme.Focused.Title).
 			Run(); err != nil {
 			return err
 		}
@@ -425,7 +426,7 @@ func runTask(ctx context.Context, cmd *cli.Command) error {
 		if err := spinner.New().
 			Title("Running task " + taskName + "...").
 			Action(func() { cmdErr = task() }).
-			Type(spinner.Dots).
+			Style(theme.Focused.Title).
 			Run(); err != nil {
 			return err
 		}

--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -87,16 +87,10 @@ var (
 						},
 						&cli.StringFlag{
 							// Use "http://cloud-api.livekit.run" in local dev
+							// Use "https://cloud-api-server-staging.ochicago1a.staging.livekit.app" in staging
 							Name:        "server-url",
 							Value:       cloudAPIServerURL,
 							Destination: &serverURL,
-							Hidden:      true,
-						},
-						&cli.StringFlag{
-							// Use "https://cloud.livekit.run" in local dev
-							Name:        "dashboard-url",
-							Value:       cloudDashboardURL,
-							Destination: &dashboardURL,
 							Hidden:      true,
 						},
 					},

--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -86,8 +86,6 @@ var (
 							Required:    true,
 						},
 						&cli.StringFlag{
-							// Use "http://cloud-api.livekit.run" in local dev
-							// Use "https://cloud-api-server-staging.ochicago1a.staging.livekit.app" in staging
 							Name:        "server-url",
 							Value:       cloudAPIServerURL,
 							Destination: &serverURL,

--- a/cmd/lk/cloud.go
+++ b/cmd/lk/cloud.go
@@ -305,6 +305,7 @@ func tryAuthIfNeeded(ctx context.Context, cmd *cli.Command) error {
 		Action(func() {
 			ak, pollErr = pollClaim(ctx, cmd)
 		}).
+		Style(theme.Focused.Title).
 		Run(); err != nil {
 		return err
 	}

--- a/cmd/lk/cloud.go
+++ b/cmd/lk/cloud.go
@@ -91,6 +91,7 @@ var (
 						},
 						&cli.StringFlag{
 							// Use "http://cloud-api.livekit.run" in local dev
+							// Use "https://cloud-api-server-staging.ochicago1a.staging.livekit.app" in staging
 							Name:        "server-url",
 							Value:       cloudAPIServerURL,
 							Destination: &serverURL,
@@ -98,6 +99,7 @@ var (
 						},
 						&cli.StringFlag{
 							// Use "https://cloud.livekit.run" in local dev
+							// Use "https://cloud-site-staging.ochicago1a.staging.livekit.app" in staging
 							Name:        "dashboard-url",
 							Value:       cloudDashboardURL,
 							Destination: &dashboardURL,

--- a/cmd/lk/cloud.go
+++ b/cmd/lk/cloud.go
@@ -90,16 +90,12 @@ var (
 							Value:       4,
 						},
 						&cli.StringFlag{
-							// Use "http://cloud-api.livekit.run" in local dev
-							// Use "https://cloud-api-server-staging.ochicago1a.staging.livekit.app" in staging
 							Name:        "server-url",
 							Value:       cloudAPIServerURL,
 							Destination: &serverURL,
 							Hidden:      true,
 						},
 						&cli.StringFlag{
-							// Use "https://cloud.livekit.run" in local dev
-							// Use "https://cloud-site-staging.ochicago1a.staging.livekit.app" in staging
 							Name:        "dashboard-url",
 							Value:       cloudDashboardURL,
 							Destination: &dashboardURL,

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.2
 
 require (
 	github.com/charmbracelet/huh v0.6.0
-	github.com/charmbracelet/huh/spinner v0.0.0-20240906163306-a9285a0ef8a3
+	github.com/charmbracelet/huh/spinner v0.0.0-20240912161303-b56e9290a68e
 	github.com/charmbracelet/lipgloss v0.13.0
 	github.com/frostbyte73/core v0.0.12
 	github.com/go-logr/logr v1.4.2
@@ -45,7 +45,7 @@ require (
 	github.com/catppuccin/go v0.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/bubbles v0.20.0 // indirect
-	github.com/charmbracelet/bubbletea v1.1.0 // indirect
+	github.com/charmbracelet/bubbletea v1.1.1 // indirect
 	github.com/charmbracelet/x/ansi v0.2.3 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240809174237-9ab0ca04ce0c // indirect
 	github.com/charmbracelet/x/term v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,12 +38,12 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/bubbles v0.20.0 h1:jSZu6qD8cRQ6k9OMfR1WlM+ruM8fkPWkHvQWD9LIutE=
 github.com/charmbracelet/bubbles v0.20.0/go.mod h1:39slydyswPy+uVOHZ5x/GjwVAFkCsV8IIVy+4MhzwwU=
-github.com/charmbracelet/bubbletea v1.1.0 h1:FjAl9eAL3HBCHenhz/ZPjkKdScmaS5SK69JAK2YJK9c=
-github.com/charmbracelet/bubbletea v1.1.0/go.mod h1:9Ogk0HrdbHolIKHdjfFpyXJmiCzGwy+FesYkZr7hYU4=
+github.com/charmbracelet/bubbletea v1.1.1 h1:KJ2/DnmpfqFtDNVTvYZ6zpPFL9iRCRr0qqKOCvppbPY=
+github.com/charmbracelet/bubbletea v1.1.1/go.mod h1:9Ogk0HrdbHolIKHdjfFpyXJmiCzGwy+FesYkZr7hYU4=
 github.com/charmbracelet/huh v0.6.0 h1:mZM8VvZGuE0hoDXq6XLxRtgfWyTI3b2jZNKh0xWmax8=
 github.com/charmbracelet/huh v0.6.0/go.mod h1:GGNKeWCeNzKpEOh/OJD8WBwTQjV3prFAtQPpLv+AVwU=
-github.com/charmbracelet/huh/spinner v0.0.0-20240906163306-a9285a0ef8a3 h1:fP1Lr+Q8rWGLCifueSnqW/2QFtZUswA3YsNOx9OesZ0=
-github.com/charmbracelet/huh/spinner v0.0.0-20240906163306-a9285a0ef8a3/go.mod h1:/dHGy3eS2ikDSO71IhslBdBGvrknQ+ze/VDiNdIxocw=
+github.com/charmbracelet/huh/spinner v0.0.0-20240912161303-b56e9290a68e h1:7j2L0HkIzFSdzDmP2Dl97Q8ttWzlwubIgiNrutMd5Lc=
+github.com/charmbracelet/huh/spinner v0.0.0-20240912161303-b56e9290a68e/go.mod h1:Cxhgl8N0sX9A+EQxedzzGZAalaF8fUVL+JP/pSOW8cI=
 github.com/charmbracelet/lipgloss v0.13.0 h1:4X3PPeoWEDCMvzDvGmTajSyYPcZM4+y8sCA/SsA3cjw=
 github.com/charmbracelet/lipgloss v0.13.0/go.mod h1:nw4zy0SBX/F/eAO1cWdcvy6qnkDUxr8Lw7dvFrAIbbY=
 github.com/charmbracelet/x/ansi v0.2.3 h1:VfFN0NUpcjBRd4DnKfRaIRo53KRgey/nhOoEqosGDEY=

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -53,12 +53,13 @@ const (
 )
 
 type Template struct {
-	Name  string   `yaml:"name" json:"name"`
-	Desc  string   `yaml:"desc" json:"description,omitempty"`
-	URL   string   `yaml:"url" json:"url,omitempty"`
-	Docs  string   `yaml:"docs" json:"docs_url,omitempty"`
-	Image string   `yaml:"image" json:"image_ref,omitempty"`
-	Tags  []string `yaml:"tags" json:"tags,omitempty"`
+	Name      string   `yaml:"name" json:"name"`
+	Desc      string   `yaml:"desc" json:"description,omitempty"`
+	URL       string   `yaml:"url" json:"url,omitempty"`
+	Docs      string   `yaml:"docs" json:"docs_url,omitempty"`
+	Image     string   `yaml:"image" json:"image_ref,omitempty"`
+	Tags      []string `yaml:"tags" json:"tags,omitempty"`
+	IsSandbox bool     `yaml:"is_sandbox" json:"is_sandbox,omitempty"`
 }
 
 func FetchTemplates(ctx context.Context) ([]Template, error) {

--- a/version.go
+++ b/version.go
@@ -15,5 +15,5 @@
 package livekitcli
 
 const (
-	Version = "2.1.0"
+	Version = "2.1.1"
 )


### PR DESCRIPTION
- Minor cleanup around sandbox/bootstrap commands
- Bump version to `2.1.1`. Though you could consider this a `2.2.0-alpha.1`, it's easier to release this way for homebrew and winget.