### PR TITLE
feat(cmd): use written install instructions instead of automatic

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -53,10 +53,12 @@ const (
 type KnownTask string
 
 const (
-	TaskInstall        KnownTask = "install"
-	TaskInstallSandbox KnownTask = "install_sandbox"
-	TaskDev            KnownTask = "dev"
-	TaskDevSandbox     KnownTask = "dev_sandbox"
+	TaskPostCreate        KnownTask = "post_create"
+	TaskPostCreateSandbox KnownTask = "post_create_sandbox"
+	TaskInstall           KnownTask = "install"
+	TaskInstallSandbox    KnownTask = "install_sandbox"
+	TaskDev               KnownTask = "dev"
+	TaskDevSandbox        KnownTask = "dev_sandbox"
 )
 
 type Template struct {
@@ -159,10 +161,15 @@ func NewTask(ctx context.Context, tf *ast.Taskfile, dir, taskName string, verbos
 		return nil, err
 	}
 
+	task := &ast.Call{
+		Task: taskName,
+	}
+	if _, err := exe.GetTask(task); err != nil {
+		return nil, err
+	}
+
 	return func() error {
-		return exe.Run(ctx, &ast.Call{
-			Task: taskName,
-		})
+		return exe.Run(ctx, task)
 	}, nil
 }
 


### PR DESCRIPTION
Instead of taking the place of tools devs are already familiar with, just print out the steps for devs to run themselves.

```sh
tobiasfried@slate /tmp % lk app sandbox --id 5lfwjtkd6cy
Using default project [Atrium]
Cloning template...
Instantiating environment...
Running task post_create_sandbox...
To setup and run the agent:

    cd /tmp/optimized-instance/agent
    python3 -m venv venv
    source venv/bin/activate
    python3 -m pip install -r requirements.txt
    python3 agent.py start

tobiasfried@slate /tmp %
```