### PR TITLE
feat(lk): refer to projects by slug-name

### DIFF
--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -40,7 +40,6 @@ var (
 	project      *config.ProjectConfig
 	AppCommands  = []*cli.Command{
 		{
-			Hidden:   true,
 			Name:     "app",
 			Category: "Core",
 			Commands: []*cli.Command{

--- a/cmd/lk/project.go
+++ b/cmd/lk/project.go
@@ -259,7 +259,11 @@ func listProjects(ctx context.Context, cmd *cli.Command) error {
 		}).
 		Headers("Name", "URL", "API Key", "Default")
 	for _, p := range cliConfig.Projects {
-		table.Row(p.Name, p.URL, p.APIKey, fmt.Sprint(p.Name == cliConfig.DefaultProject))
+		name, err := p.URLSafeName()
+		if err != nil {
+			return err
+		}
+		table.Row(name, p.URL, p.APIKey, fmt.Sprint(p.Name == cliConfig.DefaultProject))
 	}
 	fmt.Println(table)
 

--- a/cmd/lk/utils.go
+++ b/cmd/lk/utils.go
@@ -228,7 +228,7 @@ func loadProjectDetails(c *cli.Command, opts ...loadOption) (*config.ProjectConf
 		if err != nil {
 			return nil, err
 		}
-		fmt.Println("Using project:", c.String("project"))
+		fmt.Println("Using project [" + theme.Focused.Title.Render(c.String("project")) + "]")
 		logDetails(c, pc)
 		return pc, nil
 	}

--- a/version.go
+++ b/version.go
@@ -15,5 +15,5 @@
 package livekitcli
 
 const (
-	Version = "2.1.5"
+	Version = "2.2.0"
 )


### PR DESCRIPTION
- unhide `lk app` subcommands
- allow referring to project by slug-names