### PR TITLE
fix(cmd): set-default should work with slug-names too

### DIFF
--- a/cmd/lk/project.go
+++ b/cmd/lk/project.go
@@ -287,14 +287,19 @@ func setDefaultProject(ctx context.Context, cmd *cli.Command) error {
 	name := cmd.Args().First()
 
 	for _, p := range cliConfig.Projects {
-		if p.Name == name {
-			cliConfig.DefaultProject = name
-			if err := cliConfig.PersistIfNeeded(); err != nil {
-				return err
+		if p.Name != name {
+			slug, err := p.URLSafeName()
+			if err != nil || slug != name {
+				continue
 			}
-			fmt.Println("Default project set to", name)
-			return nil
 		}
+
+		cliConfig.DefaultProject = p.Name
+		if err := cliConfig.PersistIfNeeded(); err != nil {
+			return err
+		}
+		fmt.Println("Default project set to [" + theme.Focused.Title.Render(p.Name) + "]")
+		return nil
 	}
 
 	return errors.New("project not found")

--- a/version.go
+++ b/version.go
@@ -15,5 +15,5 @@
 package livekitcli
 
 const (
-	Version = "2.2.0"
+	Version = "2.2.1"
 )


### PR DESCRIPTION
`--project` accepts "Canonical names" as well as slug-names. Other project commands should follow the same semantics.