### PR TITLE
fix(auth): allow opening browser to fail silently during auth

### DIFF
--- a/cmd/lk/cloud.go
+++ b/cmd/lk/cloud.go
@@ -294,9 +294,7 @@ func tryAuthIfNeeded(ctx context.Context, cmd *cli.Command) error {
 
 	// poll for keys
 	fmt.Printf("Please confirm access by visiting:\n\n   %s\n\n", authURL.String())
-	if err := browser.OpenURL(authURL.String()); err != nil {
-		return err
-	}
+	browser.OpenURL(authURL.String()) // discard result; this will fail in headless environments
 
 	var ak *ClaimAccessKeyResponse
 	var pollErr error


### PR DESCRIPTION
https://linear.app/livekit/issue/DEX-810/fail-gracefully-when-lk-cloud-auth-cannot-open-a-browser-window

It's okay if `lk cloud auth` can't open in a browser window. This is expected in Docker containers, and it is sufficient that we print the URL to do so manually.