### PR TITLE
Standardize safe names on project auth

### DIFF
--- a/cmd/lk/cloud.go
+++ b/cmd/lk/cloud.go
@@ -294,7 +294,7 @@ func tryAuthIfNeeded(ctx context.Context, cmd *cli.Command) error {
 
 	// poll for keys
 	fmt.Printf("Please confirm access by visiting:\n\n   %s\n\n", authURL.String())
-	browser.OpenURL(authURL.String()) // discard result; this will fail in headless environments
+	_ = browser.OpenURL(authURL.String()) // discard result; this will fail in headless environments
 
 	var ak *ClaimAccessKeyResponse
 	var pollErr error
@@ -325,7 +325,10 @@ func tryAuthIfNeeded(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	// make sure name is unique
-	var name = ak.ProjectName
+	name, err := URLSafeName(ak.URL)
+	if err != nil {
+		return err
+	}
 	if cliConfig.ProjectExists(name) {
 		if err := huh.NewInput().
 			Title("Project name already exists, please choose a different name").

--- a/cmd/lk/project.go
+++ b/cmd/lk/project.go
@@ -259,11 +259,7 @@ func listProjects(ctx context.Context, cmd *cli.Command) error {
 		}).
 		Headers("Name", "URL", "API Key", "Default")
 	for _, p := range cliConfig.Projects {
-		name, err := p.URLSafeName()
-		if err != nil {
-			return err
-		}
-		table.Row(name, p.URL, p.APIKey, fmt.Sprint(p.Name == cliConfig.DefaultProject))
+		table.Row(p.Name, p.URL, p.APIKey, fmt.Sprint(p.Name == cliConfig.DefaultProject))
 	}
 	fmt.Println(table)
 
@@ -288,10 +284,7 @@ func setDefaultProject(ctx context.Context, cmd *cli.Command) error {
 
 	for _, p := range cliConfig.Projects {
 		if p.Name != name {
-			slug, err := p.URLSafeName()
-			if err != nil || slug != name {
-				continue
-			}
+			continue
 		}
 
 		cliConfig.DefaultProject = p.Name

--- a/cmd/lk/utils.go
+++ b/cmd/lk/utils.go
@@ -20,15 +20,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
-	"github.com/livekit/protocol/utils/interceptors"
 	"github.com/twitchtv/twirp"
 	"github.com/urfave/cli/v3"
+
+	"github.com/livekit/protocol/utils/interceptors"
 
 	"github.com/livekit/livekit-cli/pkg/config"
 )
@@ -282,4 +284,17 @@ func loadProjectDetails(c *cli.Command, opts ...loadOption) (*config.ProjectConf
 
 	// cannot happen
 	return pc, nil
+}
+
+func URLSafeName(projectURL string) (string, error) {
+	parsed, err := url.Parse(projectURL)
+	if err != nil {
+		return "", errors.New("invalid URL")
+	}
+	subdomain := strings.Split(parsed.Hostname(), ".")[0]
+	lastHyphen := strings.LastIndex(subdomain, "-")
+	if lastHyphen == -1 {
+		return subdomain, nil
+	}
+	return subdomain[:lastHyphen], nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"path"
 	"strings"
@@ -37,19 +36,6 @@ type ProjectConfig struct {
 	URL       string `yaml:"url"`
 	APIKey    string `yaml:"api_key"`
 	APISecret string `yaml:"api_secret"`
-}
-
-func (p *ProjectConfig) URLSafeName() (string, error) {
-	parsed, err := url.Parse(p.URL)
-	if err != nil {
-		return "", errors.New("invalid URL")
-	}
-	subdomain := strings.Split(parsed.Hostname(), ".")[0]
-	lastHyphen := strings.LastIndex(subdomain, "-")
-	if lastHyphen == -1 {
-		return subdomain, nil
-	}
-	return subdomain[:lastHyphen], nil
 }
 
 func LoadDefaultProject() (*ProjectConfig, error) {
@@ -78,9 +64,6 @@ func LoadProject(name string) (*ProjectConfig, error) {
 
 	for _, p := range conf.Projects {
 		if p.Name == name {
-			return &p, nil
-		}
-		if prefix, _ := p.URLSafeName(); prefix == name {
 			return &p, nil
 		}
 	}


### PR DESCRIPTION
the rest of tooling is set to use the standard name. doing it on the reader path tend to create inconsistencies in behavior (for example set-default did not work for me)