### PR TITLE
feat(docs+cmd): document bootstrap feature, add template list

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,50 +97,13 @@ lk app create --template <template_name> my-app
 
 Then follow the CLI prompts to finish your setup.
 
-The `--template` flag may be omitted to see a list of all available templates, or can be chosen from a selection of our first-party templates:
+For a list of all available templates, run:
 
-<table>
-  <thead><tr><th>Template Name</th><th>Language/Framework</th><th>Description</th></tr></thead>
-  <tbody>
-    <tr>
-      <td><a href="https://github.com/livekit-examples/voice-assistant-frontend">voice-assistant-frontend</a></td>
-      <td>TypeScript/Next.js</td>
-      <td>Voice assistant frontend with integrated token server</td>
-    </tr>
-    <tr>
-      <td><a href="https://github.com/livekit-examples/meet">meet</a></td>
-      <td>TypeScript/Next.js</td>
-      <td>Video conferencing frontend with integrated token server</td>
-    </tr>
-    <tr>
-      <td><a href="https://github.com/livekit-examples/multimodal-agent-python">multimodal-agent-python</a></td>
-      <td>Python</td>
-      <td>Multimodal agent with speech-to-speech and transcription capabilities</td>
-    </tr>
-    <tr>
-      <td><a href="https://github.com/livekit-examples/voice-pipeline-agent-python">voice-pipeline-agent-python</a></td>
-      <td>Python</td>
-      <td>Voice agent using modular TTS, LLM, and STT capabilities</td>
-    </tr>
-    <tr>
-      <td><a href="https://github.com/livekit-examples/multimodal-agent-node">multimodal-agent-node</a></td>
-      <td>Node.js/TypeScript</td>
-      <td>Multimodal agent with speech-to-speech and transcription capabilities</td>
-    </tr>
-    <tr>
-      <td><a href="https://github.com/livekit-examples/token-server-node">token-server-node</a></td>
-      <td>Node.js/TypeScript</td>
-      <td>Token server for generating access tokens</td>
-    </tr>
-    <tr>
-      <td><a href="https://github.com/livekit-examples/android-voice-assistant">android-voice-assistant</a></td>
-      <td>Kotlin/Android</td>
-      <td>Voice assistant mobile application</td>
-    </tr>
-  </tbody>
-</table>
+```shell
+lk app list-templates
+```
 
-For more information on templates, see the [LiveKit Template Index](https://github.com/livekit-examples/index?tab=readme-ov-file).
+See the [LiveKit Templates Index](https://github.com/livekit-examples/index?tab=readme-ov-file) for details about templates, and for instructions on how to contribute your own.
 
 ## Publishing to a room
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@
 
 This package includes command line utilities that interacts with LiveKit. It allows you to:
 
+-   Bootstrap new applications from templates
 -   Create access tokens
--   Access LiveKit APIs, create, delete rooms, etc.
+-   Access LiveKit APIs, create and delete rooms, etc.
 -   Join a room as a participant, inspecting in-room events
--   Start and manage Egress
+-   Start and manage Egresses
 -   Perform load testing, efficiently simulating real-world load
 
 # Installation
@@ -55,7 +56,7 @@ make install
 
 # Usage
 
-See `lk --help` for a complete list of subcommands.
+See `lk --help` for a complete list of subcommands. The `--help` flag can also be used on any subcommand for more information.
 
 ## Set up your project (new)
 
@@ -85,6 +86,61 @@ lk project list
 ```shell
 lk project set-default <project_name>
 ```
+
+## Bootstrapping an application
+
+The LiveKit CLI can help you bootstrap applications from a number of convenient template repositories, using your project credentials to set up required environment variables and other configuration automatically. To create an application from a template, run the following:
+
+```shell
+lk app create --template <template_name> my-app
+```
+
+Then follow the CLI prompts to finish your setup.
+
+The `--template` flag may be omitted to see a list of all available templates, or can be chosen from a selection of our first-party templates:
+
+<table>
+  <thead><tr><th>Template Name</th><th>Language/Framework</th><th>Description</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><a href="https://github.com/livekit-examples/voice-assistant-frontend">voice-assistant-frontend</a></td>
+      <td>TypeScript/Next.js</td>
+      <td>Voice assistant frontend with integrated token server</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/livekit-examples/meet">meet</a></td>
+      <td>TypeScript/Next.js</td>
+      <td>Video conferencing frontend with integrated token server</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/livekit-examples/multimodal-agent-python">multimodal-agent-python</a></td>
+      <td>Python</td>
+      <td>Multimodal agent with speech-to-speech and transcription capabilities</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/livekit-examples/voice-pipeline-agent-python">voice-pipeline-agent-python</a></td>
+      <td>Python</td>
+      <td>Voice agent using modular TTS, LLM, and STT capabilities</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/livekit-examples/multimodal-agent-node">multimodal-agent-node</a></td>
+      <td>Node.js/TypeScript</td>
+      <td>Multimodal agent with speech-to-speech and transcription capabilities</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/livekit-examples/token-server-node">token-server-node</a></td>
+      <td>Node.js/TypeScript</td>
+      <td>Token server for generating access tokens</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/livekit-examples/android-voice-assistant">android-voice-assistant</a></td>
+      <td>Kotlin/Android</td>
+      <td>Voice assistant mobile application</td>
+    </tr>
+  </tbody>
+</table>
+
+For more information on templates, see the [LiveKit Template Index](https://github.com/livekit-examples/index?tab=readme-ov-file).
 
 ## Publishing to a room
 

--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/huh/spinner"
@@ -218,7 +219,9 @@ func setupTemplate(ctx context.Context, cmd *cli.Command) error {
 			WithTheme(theme)
 		var options []huh.Option[string]
 		for _, t := range templateOptions {
-			options = append(options, huh.NewOption(t.Name, t.URL))
+			descStyle := theme.Help.ShortDesc
+			optionText := t.Name + " " + descStyle.Render("#"+strings.Join(t.Tags, " #"))
+			options = append(options, huh.NewOption(optionText, t.URL))
 		}
 		templateSelect.(*huh.Select[string]).Options(options...)
 		preinstallPrompts = append(preinstallPrompts, templateSelect)

--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -196,7 +196,7 @@ func listTemplates(ctx context.Context, cmd *cli.Command) error {
 		for _, t := range templates {
 			table.Row(
 				t.Name,
-				strings.Join(wrapToLines(t.Desc, 40), "\n"),
+				strings.Join(wrapToLines(t.Desc, maxDescLength), "\n"),
 				strings.Join(t.Tags, ", "),
 			)
 		}

--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -80,6 +80,12 @@ var (
 					},
 				},
 				{
+					Name:   "list-templates",
+					Usage:  "List available templates to bootstrap a new application",
+					Flags:  []cli.Flag{jsonFlag},
+					Action: listTemplates,
+				},
+				{
 					Hidden:    true,
 					Name:      "install",
 					Usage:     "Execute installation defined in " + bootstrap.TaskFile,
@@ -174,6 +180,29 @@ func requireProject(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	return err
+}
+
+func listTemplates(ctx context.Context, cmd *cli.Command) error {
+	templates, err := bootstrap.FetchTemplates(ctx)
+	if err != nil {
+		return err
+	}
+
+	if cmd.Bool("json") {
+		PrintJSON(templates)
+	} else {
+		const maxDescLength = 40
+		table := CreateTable().Headers("Template", "Description", "Tags")
+		for _, t := range templates {
+			table.Row(
+				t.Name,
+				strings.Join(wrapToLines(t.Desc, 40), "\n"),
+				strings.Join(t.Tags, ", "),
+			)
+		}
+		fmt.Println(table)
+	}
+	return nil
 }
 
 func setupTemplate(ctx context.Context, cmd *cli.Command) error {

--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -191,13 +191,15 @@ func listTemplates(ctx context.Context, cmd *cli.Command) error {
 	if cmd.Bool("json") {
 		PrintJSON(templates)
 	} else {
-		const maxDescLength = 40
-		table := CreateTable().Headers("Template", "Description", "Tags")
+		const maxDescLength = 64
+		table := CreateTable().Headers("Template", "Description").BorderRow(true)
 		for _, t := range templates {
+			desc := strings.Join(wrapToLines(t.Desc, maxDescLength), "\n")
+			url := theme.Focused.Title.Render(t.URL)
+			tags := theme.Help.ShortDesc.Render("#" + strings.Join(t.Tags, " #"))
 			table.Row(
 				t.Name,
-				strings.Join(wrapToLines(t.Desc, maxDescLength), "\n"),
-				strings.Join(t.Tags, ", "),
+				desc+"\n\n"+url+"\n"+tags,
 			)
 		}
 		fmt.Println(table)

--- a/cmd/lk/project.go
+++ b/cmd/lk/project.go
@@ -262,9 +262,15 @@ func listProjects(ctx context.Context, cmd *cli.Command) error {
 					return baseStyle
 				}
 			}).
-			Headers("Name", "URL", "API Key", "Default")
+			Headers("Name", "URL", "API Key")
 		for _, p := range cliConfig.Projects {
-			table.Row(p.Name, p.URL, p.APIKey, fmt.Sprint(p.Name == cliConfig.DefaultProject))
+			var pName string
+			if p.Name == cliConfig.DefaultProject {
+				pName = "* " + p.Name
+			} else {
+				pName = "  " + p.Name
+			}
+			table.Row(pName, p.URL, p.APIKey)
 		}
 		fmt.Println(table)
 	}

--- a/cmd/lk/utils.go
+++ b/cmd/lk/utils.go
@@ -160,6 +160,38 @@ func wrapWith(wrap string) func(string) string {
 	}
 }
 
+func ellipsizeTo(str string, maxLength int) string {
+	if len(str) <= maxLength {
+		return str
+	}
+	ellipsis := "..."
+	contentLen := max(0, min(len(str), maxLength-len(ellipsis)))
+	return str[:contentLen] + ellipsis
+}
+
+func wrapToLines(input string, maxLineLength int) []string {
+	words := strings.Fields(input)
+	var lines []string
+	var currentLine strings.Builder
+
+	for _, word := range words {
+		if currentLine.Len()+len(word)+1 > maxLineLength {
+			lines = append(lines, currentLine.String())
+			currentLine.Reset()
+		}
+		if currentLine.Len() > 0 {
+			currentLine.WriteString(" ")
+		}
+		currentLine.WriteString(word)
+	}
+
+	if currentLine.Len() > 0 {
+		lines = append(lines, currentLine.String())
+	}
+
+	return lines
+}
+
 // Provides a temporary path, a function to relocate it to a permanent path,
 // and a function to clean up the temporary path that should always be deferred
 // in the case of a failure to relocate.

--- a/cmd/lk/utils_test.go
+++ b/cmd/lk/utils_test.go
@@ -56,3 +56,34 @@ func TestMapStrings(t *testing.T) {
 		t.Error("mapStrings should apply the function to all elements")
 	}
 }
+
+func TestEllipziseTo(t *testing.T) {
+	str := "This is some long string that should be ellipsized"
+	ellipsized := ellipsizeTo(str, 12)
+	if len(ellipsized) != 12 {
+		t.Error("ellipsizeTo should return a string of the specified length")
+	}
+	if ellipsized != "This is s..." {
+		t.Error("ellipsizeTo should ellipsize the string")
+	}
+}
+
+func TestWrapToLines(t *testing.T) {
+	str := "This is a long string that should be wrapped to multiple lines"
+	wrapped := wrapToLines(str, 10)
+	if len(wrapped) != 8 {
+		t.Error("wrapToLines should return a slice of lines")
+	}
+	if !slices.Equal([]string{
+		"This is a",
+		"long",
+		"string",
+		"that",
+		"should be",
+		"wrapped to",
+		"multiple",
+		"lines",
+	}, wrapped) {
+		t.Error("wrapToLines should wrap the string to the specified width")
+	}
+}

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -67,14 +67,15 @@ var templateIgnoreFiles = []string{
 }
 
 type Template struct {
-	Name      string   `yaml:"name" json:"name"`
-	Desc      string   `yaml:"desc" json:"description,omitempty"`
-	URL       string   `yaml:"url" json:"url,omitempty"`
-	Docs      string   `yaml:"docs" json:"docs_url,omitempty"`
-	Image     string   `yaml:"image" json:"image_ref,omitempty"`
-	Tags      []string `yaml:"tags" json:"tags,omitempty"`
-	Requires  []string `yaml:"requires" json:"requires,omitempty"`
-	IsSandbox bool     `yaml:"is_sandbox" json:"is_sandbox,omitempty"`
+	Name      string            `yaml:"name" json:"name"`
+	Desc      string            `yaml:"desc" json:"description,omitempty"`
+	URL       string            `yaml:"url" json:"url,omitempty"`
+	Docs      string            `yaml:"docs" json:"docs_url,omitempty"`
+	Image     string            `yaml:"image" json:"image_ref,omitempty"`
+	Tags      []string          `yaml:"tags" json:"tags,omitempty"`
+	Attrs     map[string]string `yaml:"attrs" json:"attrs,omitempty"`
+	Requires  []string          `yaml:"requires" json:"requires,omitempty"`
+	IsSandbox bool              `yaml:"is_sandbox" json:"is_sandbox,omitempty"`
 }
 
 type SandboxDetails struct {

--- a/version.go
+++ b/version.go
@@ -15,5 +15,5 @@
 package livekitcli
 
 const (
-	Version = "2.2.1"
+	Version = "2.3.0"
 )


### PR DESCRIPTION
- Bump version to `2.3.0`
- Add instructions for bootstrapping an app from template
- Prints template tags next to name when listing

<img width="690" alt="Screenshot 2024-10-29 at 6 21 46 PM" src="https://github.com/user-attachments/assets/37e7ec19-7f93-42f5-bf79-18c87b883638">

- Adds `lk app list-templates` command, with table or `--json` output
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/693c9b60-cbbc-4b7d-a346-7bed5ccef1a7">

- Shows default project with `*` instead of a whole table column dedicated to it