### PR TITLE
chore(cmd): strip additional files when degitting

### DIFF
--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -311,6 +311,7 @@ func instantiateEnv(ctx context.Context, cmd *cli.Command, rootPath string, addl
 	prompt := func(key, oldValue string) (string, error) {
 		var newValue string
 		if err := huh.NewInput().
+			EchoMode(huh.EchoModePassword).
 			Title("Enter " + key + "?").
 			Placeholder(oldValue).
 			Value(&newValue).


### PR DESCRIPTION
https://linear.app/livekit/issue/DEX-938/clean-up-additional-files-on-bootstrap

- Removes additional unneeded files when bootstrapping a template: `.git/` `taskfile.yaml`, `renovate.json`, `TEMPLATE.md`