### PR TITLE
feat(cmd): better ergonomics around `lk app` and templates

### DIFF
--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -103,14 +103,20 @@ var (
 							Usage:   "Write environment variables to .env.local file",
 						},
 					},
-					Before: requireProject,
+					ArgsUsage: "[DIR] location of the project directory (default: current directory)",
+					Before:    requireProject,
 					Action: func(ctx context.Context, cmd *cli.Command) error {
-						env, err := instantiateEnv(ctx, cmd, ".", nil)
+						rootDir := cmd.Args().First()
+						if rootDir == "" {
+							rootDir = "."
+						}
+
+						env, err := instantiateEnv(ctx, cmd, rootDir, nil)
 						if err != nil {
 							return err
 						}
 						if cmd.Bool("write") {
-							return bootstrap.WriteDotEnv(".", env)
+							return bootstrap.WriteDotEnv(rootDir, env)
 						} else {
 							return bootstrap.PrintDotEnv(env)
 						}

--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -366,6 +366,9 @@ func doPostCreate(ctx context.Context, _ *cli.Command, rootPath string, verbose 
 	if err != nil {
 		return err
 	}
+	if tf == nil {
+		return nil
+	}
 
 	task, err := bootstrap.NewTask(ctx, tf, rootPath, string(bootstrap.TaskPostCreate), verbose)
 	if task == nil || err != nil {

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"os/exec"
@@ -121,7 +122,14 @@ func FetchSandboxDetails(ctx context.Context, sid, token, serverURL string) (*Sa
 }
 
 func ParseTaskfile(rootPath string) (*ast.Taskfile, error) {
-	file, err := os.ReadFile(path.Join(rootPath, TaskFile))
+	taskfilePath := path.Join(rootPath, TaskFile)
+
+	// taskfile.yaml is optional
+	if _, err := os.Stat(taskfilePath); err != nil && errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+
+	file, err := os.ReadFile(taskfilePath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- `lk app env` command is no longer hidden
- `lk app env` now prints to stdout instead of clobbering `.env.local` unexpectedly, but can be called with the `--write` flag to keep previous behavior
- `lk app env [DIR]` is now supported, allowing you tun run outside CWD
- We no longer print an error if a template cloned using `lk app create` does not contain a `taskfile.yaml`, it is now considered optional

NOTE: we no longer recursively search the whole project for `.env.example` files -- only in the root directory. This means that we don't support "meta templates" that stitch together other templates to make a full application stack, but we were not using it anyway, and prefer to direct users to bootstrap each component separately.