### PR TITLE
Add a clearer error message for invalid sandbox id

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -111,6 +111,9 @@ func FetchSandboxDetails(ctx context.Context, sid, token, serverURL string) (*Sa
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode == 404 {
+		return nil, fmt.Errorf("Sandbox not found: %s", sid)
+	}
 	if resp.StatusCode != 200 {
 		return nil, errors.New(resp.Status)
 	}

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -112,7 +112,7 @@ func FetchSandboxDetails(ctx context.Context, sid, token, serverURL string) (*Sa
 		return nil, err
 	}
 	if resp.StatusCode == 404 {
-		return nil, fmt.Errorf("Sandbox not found: %s", sid)
+		return nil, fmt.Errorf("sandbox not found: %s", sid)
 	}
 	if resp.StatusCode != 200 {
 		return nil, errors.New(resp.Status)


### PR DESCRIPTION
previously the command just said `404 Not Found` and it wasn't obvious the problem was the sandbox param, vs the template param.