### PR TITLE
Allow custom env file paths

### DIFF
--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -31,16 +31,16 @@ import (
 )
 
 var (
-	template     *bootstrap.Template
-	templateName string
-	templateURL  string
-	sandboxID    string
-	appName      string
-	appNameRegex = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_-]*$`)
-	outputFile   string
-	exampleFile  string
-	project      *config.ProjectConfig
-	AppCommands  = []*cli.Command{
+	template        *bootstrap.Template
+	templateName    string
+	templateURL     string
+	sandboxID       string
+	appName         string
+	appNameRegex    = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_-]*$`)
+	destinationFile string
+	exampleFile     string
+	project         *config.ProjectConfig
+	AppCommands     = []*cli.Command{
 		{
 			Name:     "app",
 			Category: "Core",
@@ -117,7 +117,7 @@ var (
 							Usage:       "Destination file path, when used with --write",
 							Value:       ".env.local",
 							TakesFile:   true,
-							Destination: &outputFile,
+							Destination: &destinationFile,
 						},
 						&cli.StringFlag{
 							Name:        "example",
@@ -392,7 +392,7 @@ func manageEnv(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	if cmd.Bool("write") {
-		return bootstrap.WriteDotEnv(rootDir, outputFile, env)
+		return bootstrap.WriteDotEnv(rootDir, destinationFile, env)
 	} else {
 		return bootstrap.PrintDotEnv(env)
 	}

--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -320,12 +320,14 @@ func setupTemplate(ctx context.Context, cmd *cli.Command) error {
 		"NEXT_PUBLIC_LIVEKIT_SANDBOX_ID": sandboxID,
 	}
 	envOutputFile := ".env.local"
-	if customOutput, ok := tf.Vars.Get("env_file").Value.(string); ok {
-		envOutputFile = customOutput
-	}
 	envExampleFile := ".env.example"
-	if customExample, ok := tf.Vars.Get("env_example").Value.(string); ok {
-		envExampleFile = customExample
+	if tf != nil {
+		if customOutput, ok := tf.Vars.Get("env_file").Value.(string); ok {
+			envOutputFile = customOutput
+		}
+		if customExample, ok := tf.Vars.Get("env_example").Value.(string); ok {
+			envExampleFile = customExample
+		}
 	}
 	env, err := instantiateEnv(ctx, cmd, appName, addlEnv, envExampleFile)
 	if err != nil {

--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -408,7 +408,6 @@ func instantiateEnv(ctx context.Context, cmd *cli.Command, rootPath string, addl
 		"LIVEKIT_URL":             project.URL,
 		"NEXT_PUBLIC_LIVEKIT_URL": project.URL,
 	}
-
 	if addlEnv != nil {
 		for k, v := range *addlEnv {
 			env[k] = v

--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -403,10 +403,8 @@ func manageEnv(ctx context.Context, cmd *cli.Command) error {
 }
 
 func instantiateEnv(ctx context.Context, cmd *cli.Command, rootPath string, addlEnv *map[string]string, exampleFile string, skipLiveKitKeys bool) (map[string]string, error) {
-	// Initialize with default values
 	env := map[string]string{}
 
-	// Only add LiveKit credentials if not disabled in taskfile
 	if !skipLiveKitKeys {
 		env = map[string]string{
 			"LIVEKIT_API_KEY":    project.APIKey,

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -40,8 +40,6 @@ import (
 )
 
 const (
-	EnvExampleFile          = ".env.example"
-	EnvLocalFile            = ".env.local"
 	TaskFile                = "taskfile.yaml"
 	TemplateIndexFile       = "templates.yaml"
 	TemplateIndexURL        = "https://raw.githubusercontent.com/livekit-examples/index/main"
@@ -190,16 +188,16 @@ type PromptFunc func(key string, value string) (string, error)
 
 // Read .env.example file if present in rootDir, replacing all `substitutions`,
 // prompting for others, and returning the result as a map.
-func InstantiateDotEnv(ctx context.Context, rootDir string, substitutions map[string]string, verbose bool, prompt PromptFunc) (map[string]string, error) {
+func InstantiateDotEnv(ctx context.Context, rootDir string, exampleFilePath string, substitutions map[string]string, verbose bool, prompt PromptFunc) (map[string]string, error) {
 	promptedVars := map[string]string{}
-	envExamplePath := path.Join(rootDir, EnvExampleFile)
+	envExamplePath := path.Join(rootDir, exampleFilePath)
 
 	stat, err := os.Stat(envExamplePath)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	} else if stat != nil {
 		if stat.IsDir() {
-			return nil, errors.New("env.example file is a directory")
+			return nil, errors.New(".env.example file is a directory")
 		}
 
 		envMap, err := godotenv.Read(envExamplePath)
@@ -239,12 +237,12 @@ func PrintDotEnv(envMap map[string]string) error {
 	return err
 }
 
-func WriteDotEnv(rootDir string, envMap map[string]string) error {
+func WriteDotEnv(rootDir string, filePath string, envMap map[string]string) error {
 	envContents, err := godotenv.Marshal(envMap)
 	if err != nil {
 		return err
 	}
-	envLocalPath := path.Join(rootDir, EnvLocalFile)
+	envLocalPath := path.Join(rootDir, filePath)
 	return os.WriteFile(envLocalPath, []byte(envContents+"\n"), 0700)
 }
 


### PR DESCRIPTION
I'm working on a swift example app for the voice assistant and it needs to get the sandbox ID loaded in, but none of the API keys. The Android example app [does this with a global variable](https://github.com/livekit-examples/android-voice-assistant/blob/main/taskfile.yaml) that gets overridden via `sed`, but the approach is brittle and a little messy. 

In Swift, the best approach is to use xcconfig files, which can be imported in as build settings. It turns out that xcconfig files basically have the same format as env files, so we can just treat them as the env files for this type and take advantage of our existing env-population code. The only issues are 
 a) the files need to be in a subdirectory
 b) it's best to give them the `.xcconfig` extension (although not strictly necessary, it can work without this)
~c) we should not install the project secrets into them~
 
This PR resolves these issues by allowing you to specify custom paths to these files. I added support for these to the taskfile's vars field and also to the `app env` command for completeness.
 
 Here's a [sample taskfile](https://github.com/livekit-examples/voice-assistant-swift/blob/main/taskfile.yaml) using these new properties, which I have tested and works exactly as desired. I haven't evaluated it yet but I'm hopeful that we can adopt the same method in android, react native, and flutter.