### PR TITLE
Point cloud users from project add to cloud auth, remember device name

### DIFF
--- a/cmd/lk/cloud.go
+++ b/cmd/lk/cloud.go
@@ -269,13 +269,19 @@ func tryAuthIfNeeded(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	// name
-	var deviceName string
+	// get devicename
+	deviceName := cliConfig.DeviceName
 	if err := huh.NewInput().
 		Title("What is the name of this device?").
 		Value(&deviceName).
 		WithTheme(util.Theme).
 		Run(); err != nil {
+		return err
+	}
+
+	// remember device name for next time
+	cliConfig.DeviceName = deviceName
+	if err := cliConfig.PersistIfNeeded(); err != nil {
 		return err
 	}
 	fmt.Println("Device:", deviceName)

--- a/cmd/lk/project.go
+++ b/cmd/lk/project.go
@@ -39,7 +39,7 @@ var (
 			Commands: []*cli.Command{
 				{
 					Name:      "add",
-					Usage:     "Add a new project",
+					Usage:     "Add a new project (for LiveKit Cloud projects, also see `lk cloud auth`)",
 					UsageText: "lk project add PROJECT_NAME",
 					ArgsUsage: "PROJECT_NAME",
 					Action:    addProject,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,7 @@ import (
 type CLIConfig struct {
 	DefaultProject string          `yaml:"default_project"`
 	Projects       []ProjectConfig `yaml:"projects"`
+	DeviceName     string          `yaml:"device_name"`
 	// absent from YAML
 	hasPersisted bool
 }


### PR DESCRIPTION
If you're trying to add cloud projects, the easiest way is with cloud auth. This fixes the help for the add command to tell you that.

I also noticed its annoying to retype your device name every time you auth a project, so I added it to the global config for reuse.