### PR TITLE
nanpa: init at 2.3.1

### DIFF
--- a/.github/bump-version.sh
+++ b/.github/bump-version.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sed -i "s/^\\tVersion.*\$/\tVersion = \"$VERSION\"/" version.go

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,18 @@
+on:
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: "packages to bump"
+        type: string
+        required: true
+
+jobs:
+  bump:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nbsp/ilo@v2
+        with:
+          packages: ${{ github.event.inputs.packages }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -16,3 +16,4 @@ jobs:
       - uses: nbsp/ilo@v2
         with:
           packages: ${{ github.event.inputs.packages }}
+          prefix: v

--- a/.nanparc
+++ b/.nanparc
@@ -1,0 +1,3 @@
+version 2.3.1
+name livekit-cli
+custom .github/bump-version.sh


### PR DESCRIPTION
this PR adds [nanpa](https://github.com/nbsp/nanpa) tooling to LiveKit CLI. on every new PR that contains code changes, make sure to add a file at `/.nanpa/something.kdl`, detailing the change:

```
patch type="added" "Add foo to bar"
minor type="security" "Oops"
```

multiple changes can be added per file. a future version of nanpa will add a handy CLI for adding them, for now they need to be added by hand. see [Keep A Changelog](https://keepachangelog.com/en/1.1.0/#how) for valid types.

when the [GitHub app](https://github.com/nbsp/ilo) detects changes, it will open an issue detailing them. when it is closed, it will run CI to tag versions. a release still doesn't happen automatically, in case of any bugs — you have to make a release from the tag yourself.

i have added the sample ilo-nanpa bump workflow but i don't know how the rest of the CI works here, so feel free to iterate.

@davidzhao we need to add the ilo-nanpa app to livekit-cli repository before merging, and to add `NANPA_WORKFLOW=bump.yml` to the repository variables (not secrets!)