### PR TITLE
Don't copy LICENSE or NOTICE files with bootstrap

### DIFF
--- a/.nanpa/no-license.kdl
+++ b/.nanpa/no-license.kdl
@@ -1,0 +1,1 @@
+patch type="added" "Do not copy LICENSE or NOTICE files during bootstrap"

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -62,6 +62,8 @@ var templateIgnoreFiles = []string{
 	"renovate.json",
 	"taskfile.yaml",
 	"TEMPLATE.md",
+	"LICENSE",
+	"LICENSE.md",
 }
 
 type Template struct {

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -64,6 +64,7 @@ var templateIgnoreFiles = []string{
 	"TEMPLATE.md",
 	"LICENSE",
 	"LICENSE.md",
+	"NOTICE",
 }
 
 type Template struct {


### PR DESCRIPTION
When a customer uses the bootstrap function to clone an example app, we intend to give them complete rights to the resulting code to basically do whatever they want.

By including the LICENSE file, we are actually causing them to apply it (whether intentional or not) if they publish it. So let's not copy it.

There's maybe a deeper issue worth considering which has to do with copyright. The Apache 2 license requires a copyright NOTICE in the repo as well as a copyright notice at the top of every source file. But it doesn't really make sense for us to copyright bootstrap templates in this way... It would be ideal if we could strip the copyright notices from the files as well or simply choose an even less restrictive license for our sample apps such as MIT.  And that could also be a requirement enforced by the tool - perhaps it should refuse to work on a repository not covered by the MIT license or similar.

In any case, this is the simple step and we can think about the rest later.