### PR TITLE
fix: fix the wrong error return value

### DIFF
--- a/pkg/loadtester/loadtest.go
+++ b/pkg/loadtester/loadtest.go
@@ -236,7 +236,7 @@ func (t *LoadTest) RunSuite(ctx context.Context) error {
 			return err
 		}
 		if ctx.Err() != nil {
-			return err
+			return ctx.Err()
 		}
 
 		var tracks, packets, dropped, errCount int64


### PR DESCRIPTION
In fact, err is incorrect and should be  `ctx.Err()`.