### PR TITLE
Support for SIP update APIs.

### DIFF
--- a/.nanpa/sip-update.kdl
+++ b/.nanpa/sip-update.kdl
@@ -1,0 +1,1 @@
+minor type="added" "support for SIP update APIs"

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/go-task/task/v3 v3.41.0
 	github.com/joho/godotenv v1.5.1
-	github.com/livekit/protocol v1.35.1-0.20250319165056-fdacb1a293e5
-	github.com/livekit/server-sdk-go/v2 v2.5.1-0.20250319165849-a5f5f6eb2bde
+	github.com/livekit/protocol v1.35.1-0.20250320161708-6d044a0462b3
+	github.com/livekit/server-sdk-go/v2 v2.5.1-0.20250321175649-e38544bea187
 	github.com/moby/buildkit v0.20.1
 	github.com/pion/rtcp v1.2.15
 	github.com/pion/rtp v1.8.13

--- a/go.sum
+++ b/go.sum
@@ -260,12 +260,12 @@ github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1 h1:jm09419p0lqTkD
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20250310153736-45596af895b6 h1:6ZhtnY9I9knfm3ieIPpznQSEU2rDECO8yliW/ANLQ7U=
 github.com/livekit/mediatransportutil v0.0.0-20250310153736-45596af895b6/go.mod h1:36s+wwmU3O40IAhE+MjBWP3W71QRiEE9SfooSBvtBqY=
-github.com/livekit/protocol v1.35.1-0.20250319165056-fdacb1a293e5 h1:onBZ5milSh7iAnapx1ju/z51bvb5RgLmlVBPdNJbg2Y=
-github.com/livekit/protocol v1.35.1-0.20250319165056-fdacb1a293e5/go.mod h1:WrT/CYRxtMNOVUjnIPm5OjWtEkmreffTeE1PRZwlRg4=
+github.com/livekit/protocol v1.35.1-0.20250320161708-6d044a0462b3 h1:RsVnIuxnj3wRzWILhpnguyrq3vrK6Cccb762GpLH3Xg=
+github.com/livekit/protocol v1.35.1-0.20250320161708-6d044a0462b3/go.mod h1:WrT/CYRxtMNOVUjnIPm5OjWtEkmreffTeE1PRZwlRg4=
 github.com/livekit/psrpc v0.6.1-0.20250205181828-a0beed2e4126 h1:fzuYpAQbCid7ySPpQWWePfQOWUrs8x6dJ0T3Wl07n+Y=
 github.com/livekit/psrpc v0.6.1-0.20250205181828-a0beed2e4126/go.mod h1:X5WtEZ7OnEs72Fi5/J+i0on3964F1aynQpCalcgMqRo=
-github.com/livekit/server-sdk-go/v2 v2.5.1-0.20250319165849-a5f5f6eb2bde h1:J/fLwtZM07vS8IfXM0aWCMvOki7QMCbvlAm37nObM0g=
-github.com/livekit/server-sdk-go/v2 v2.5.1-0.20250319165849-a5f5f6eb2bde/go.mod h1:egApdq6lVge9rOvsJuvkyRClq18yytLNLiriY38p8WI=
+github.com/livekit/server-sdk-go/v2 v2.5.1-0.20250321175649-e38544bea187 h1:TNQSR/4p23qmfGbt0Pku0TMsN/pwud0ZSsxeZJUGF+s=
+github.com/livekit/server-sdk-go/v2 v2.5.1-0.20250321175649-e38544bea187/go.mod h1:4Kt0/NmSvMW0Jg4fo1YK0rk4EAmaf3LDi8DKzYrmDIc=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=


### PR DESCRIPTION
Support both replace and incremental update action for SIP trunks and dispatch rules.

Replace the whole trunk with a new JSON:
```
lk sip inbound update --id ST_XYZ trunk.json
```

Update specific trunk fields:
```
lk sip inbound update --id ST_XYZ --name "Test trunk"
```
