### PR TITLE
add support for project lookup via subdomain

### DIFF
--- a/.nanpa/project-config-subdomain.kdl
+++ b/.nanpa/project-config-subdomain.kdl
@@ -1,0 +1,1 @@
+minor type="changed" "updated project config loading to support subdomain"

--- a/cmd/lk/agent.go
+++ b/cmd/lk/agent.go
@@ -204,11 +204,6 @@ var (
 					Before: createAgentClient,
 					Flags: []cli.Flag{
 						nameSliceFlag,
-						&cli.StringFlag{
-							Name:     "project",
-							Usage:    "Project to list agents for",
-							Required: false,
-						},
 					},
 				},
 				{

--- a/cmd/lk/utils.go
+++ b/cmd/lk/utils.go
@@ -50,6 +50,7 @@ var (
 			Name:    "url",
 			Usage:   "`URL` to LiveKit instance",
 			Sources: cli.EnvVars("LIVEKIT_URL"),
+			Value:   "http://localhost:7880",
 		},
 		&cli.StringFlag{
 			Name:    "api-key",

--- a/cmd/lk/utils.go
+++ b/cmd/lk/utils.go
@@ -50,7 +50,6 @@ var (
 			Name:    "url",
 			Usage:   "`URL` to LiveKit instance",
 			Sources: cli.EnvVars("LIVEKIT_URL"),
-			Value:   "http://localhost:7880",
 		},
 		&cli.StringFlag{
 			Name:    "api-key",
@@ -65,6 +64,10 @@ var (
 		&cli.StringFlag{
 			Name:  "project",
 			Usage: "`NAME` of a configured project",
+		},
+		&cli.StringFlag{
+			Name:  "subdomain",
+			Usage: "`SUBDOMAIN` of a configured project",
 		},
 		&cli.BoolFlag{
 			Name:        "curl",
@@ -167,6 +170,17 @@ func loadProjectDetails(c *cli.Command, opts ...loadOption) (*config.ProjectConf
 			return nil, err
 		}
 		fmt.Println("Using project [" + util.Theme.Focused.Title.Render(c.String("project")) + "]")
+		logDetails(c, pc)
+		return pc, nil
+	}
+
+	// if explicit subdomain is provided, use it
+	if c.String("subdomain") != "" {
+		pc, err := config.LoadProjectBySubdomain(c.String("subdomain"))
+		if err != nil {
+			return nil, err
+		}
+		fmt.Println("Using project [" + util.Theme.Focused.Title.Render(pc.Name) + "]")
 		logDetails(c, pc)
 		return pc, nil
 	}


### PR DESCRIPTION
- more explicit path'ing and workdir for agent hosting commands
- add the subdomain project lookup to support agent hosting toml
- for agent hosting list command, add a project-id param to allow listing agents on projects other than the default project