### PR TITLE
fix(room): corrects behavior of room commands with short arg variants

### DIFF
--- a/version.go
+++ b/version.go
@@ -15,5 +15,5 @@
 package livekitcli
 
 const (
-	Version = "2.4.0"
+	Version = "2.4.1"
 )


### PR DESCRIPTION
Long flag forms were being shadowed by short variants in some commands, leading to incorrect parsing in `lk room mute-track`, `lk room update-subscriptions`.

https://linear.app/livekit/issue/DEVM-567/fix-unmute-issue-with-long-option-in-lk-command