### PR TITLE
Add a flag for using dev credentials

### DIFF
--- a/.nanpa/dev-flag.kdl
+++ b/.nanpa/dev-flag.kdl
@@ -1,0 +1,1 @@
+minor type="added" "flag for using dev credentials"


### PR DESCRIPTION
This change adds `--dev` flag that uses the same credentials as LiveKit server's `--dev` flag.