### PR TITLE
feat(agents): support int and float cpu cfg values

### DIFF
--- a/cmd/lk/main.go
+++ b/cmd/lk/main.go
@@ -58,6 +58,7 @@ func main() {
 	}
 
 	app.Commands = append(app.Commands, AppCommands...)
+	app.Commands = append(app.Commands, AgentCommands...)
 	app.Commands = append(app.Commands, CloudCommands...)
 	app.Commands = append(app.Commands, ProjectCommands...)
 	app.Commands = append(app.Commands, RoomCommands...)
@@ -69,7 +70,6 @@ func main() {
 	app.Commands = append(app.Commands, SIPCommands...)
 	app.Commands = append(app.Commands, ReplayCommands...)
 	app.Commands = append(app.Commands, LoadTestCommands...)
-	app.Commands = append(app.Commands, AgentCommands...)
 
 	// Register cleanup hook for SIGINT, SIGTERM, SIGQUIT
 	ctx, stop := signal.NotifyContext(

--- a/pkg/agentfs/config-file.go
+++ b/pkg/agentfs/config-file.go
@@ -25,13 +25,29 @@ import (
 )
 
 type AgentTOML struct {
-	ProjectSubdomain string `toml:"project_subdomain"`
-	Name             string `toml:"name"`
-	CPU              string `toml:"cpu"`
-	Replicas         int    `toml:"replicas"`
-	MaxReplicas      int    `toml:"max_replicas"`
+	ProjectSubdomain string    `toml:"project_subdomain"`
+	Name             string    `toml:"name"`
+	CPU              CPUString `toml:"cpu"`
+	Replicas         int       `toml:"replicas"`
+	MaxReplicas      int       `toml:"max_replicas"`
 
 	Regions []string `toml:"regions"`
+}
+
+type CPUString string
+
+func (c *CPUString) UnmarshalTOML(v interface{}) error {
+	switch value := v.(type) {
+	case int64:
+		*c = CPUString(fmt.Sprintf("%d", value))
+	case float64:
+		*c = CPUString(fmt.Sprintf("%g", value))
+	case string:
+		*c = CPUString(value)
+	default:
+		return fmt.Errorf("invalid type for cpu: %T", v)
+	}
+	return nil
 }
 
 const (


### PR DESCRIPTION
`livekit.toml` now supports `cpu` values of ints and floats too. I tripped up on it once before and it seems awkward not to.