### PR TITLE
fix(agents): correct logic for agents secrets flags

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -135,12 +135,14 @@ func ParseTaskfile(rootPath string) (*ast.Taskfile, error) {
 		return nil, nil
 	}
 
-	file, err := os.ReadFile(taskfilePath)
+	file, err := os.Open(taskfilePath)
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
+
 	tf := &ast.Taskfile{}
-	if err := yaml.Unmarshal(file, tf); err != nil {
+	if err := yaml.NewDecoder(file).Decode(tf); err != nil {
 		return nil, err
 	}
 	return tf, nil


### PR DESCRIPTION
https://linear.app/livekit/issue/HA-95/secret-file-required-even-when-providing-secrets

Fix logic around agent secrets:
- None required for `lk agent deploy`
- Use lazy exaluation if secrets set via flags in `lk agent update-secrets`