### PR TITLE
fix(app): allow bootstrapping of templates without authenticating

### DIFF
--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -32,6 +32,10 @@ import (
 )
 
 var (
+	ErrNoProjectSelected = errors.New("no project selected")
+)
+
+var (
 	template        *bootstrap.Template
 	templateName    string
 	templateURL     string
@@ -49,7 +53,6 @@ var (
 				{
 					Name:      "create",
 					Usage:     "Bootstrap a new application from a template or through guided creation",
-					Before:    requireProject,
 					Action:    setupTemplate,
 					ArgsUsage: "`APP_NAME`",
 					Flags: []cli.Flag{
@@ -179,7 +182,7 @@ func requireProject(ctx context.Context, cmd *cli.Command) (context.Context, err
 				}
 				return requireProject(ctx, cmd)
 			} else {
-				return nil, errors.New("no project selected")
+				return nil, ErrNoProjectSelected
 			}
 		}
 	}
@@ -413,12 +416,21 @@ func manageEnv(ctx context.Context, cmd *cli.Command) error {
 }
 
 func instantiateEnv(ctx context.Context, cmd *cli.Command, rootPath string, addlEnv *map[string]string, exampleFile string) (map[string]string, error) {
-	env := map[string]string{
-		"LIVEKIT_API_KEY":         project.APIKey,
-		"LIVEKIT_API_SECRET":      project.APISecret,
-		"LIVEKIT_URL":             project.URL,
-		"NEXT_PUBLIC_LIVEKIT_URL": project.URL,
+	env := map[string]string{}
+	if _, err := requireProject(ctx, cmd); err != nil {
+		if !errors.Is(err, ErrNoProjectSelected) {
+			return nil, err
+		}
+		// if no project is selected, we prompt for all environment variables including LIVEKIT_ ones
+	} else {
+		env = map[string]string{
+			"LIVEKIT_API_KEY":         project.APIKey,
+			"LIVEKIT_API_SECRET":      project.APISecret,
+			"LIVEKIT_URL":             project.URL,
+			"NEXT_PUBLIC_LIVEKIT_URL": project.URL,
+		}
 	}
+
 	if addlEnv != nil {
 		for k, v := range *addlEnv {
 			env[k] = v

--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -153,7 +153,7 @@ func requireProject(ctx context.Context, cmd *cli.Command) (context.Context, err
 		if len(cliConfig.Projects) > 0 {
 			var options []huh.Option[*config.ProjectConfig]
 			for _, p := range cliConfig.Projects {
-				options = append(options, huh.NewOption(p.Name+" ["+p.APIKey+"]", &p))
+				options = append(options, huh.NewOption(p.Name+" ["+util.ExtractSubdomain(p.URL)+"]", &p))
 			}
 			if err = huh.NewForm(
 				huh.NewGroup(huh.NewSelect[*config.ProjectConfig]().

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"regexp"
 	"strings"
 
+	"github.com/livekit/livekit-cli/v2/pkg/util"
 	"gopkg.in/yaml.v3"
 )
 
@@ -70,17 +70,8 @@ func LoadProjectBySubdomain(subdomain string) (*ProjectConfig, error) {
 
 	fmt.Println("Loading project by subdomain", subdomain)
 
-	extractSubdomain := func(url string) string {
-		subdomainPattern := regexp.MustCompile(`^(?:https?|wss?)://([^.]+)\.`)
-		matches := subdomainPattern.FindStringSubmatch(url)
-		if len(matches) > 1 {
-			return matches[1]
-		}
-		return ""
-	}
-
 	for _, p := range conf.Projects {
-		projectSubdomain := extractSubdomain(p.URL)
+		projectSubdomain := util.ExtractSubdomain(p.URL)
 		if projectSubdomain == subdomain {
 			return &p, nil
 		}

--- a/pkg/util/url.go
+++ b/pkg/util/url.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"regexp"
+)
+
+func ExtractSubdomain(url string) string {
+	subdomainPattern := regexp.MustCompile(`^(?:https?|wss?)://([^.]+)\.`)
+	matches := subdomainPattern.FindStringSubmatch(url)
+	if len(matches) > 1 {
+		return matches[1]
+	}
+	return ""
+}

--- a/version.go
+++ b/version.go
@@ -15,5 +15,5 @@
 package livekitcli
 
 const (
-	Version = "2.4.5"
+	Version = "2.4.6"
 )


### PR DESCRIPTION
Fixes [this issue](https://github.com/livekit-examples/voice-assistant-frontend/issues/114) in which project credentials were required to bootstrap. We now defer until after cloning the template to check for project credentials, and if you opt not to use any local ones or to auth with a browser, we simply allow you to progress and prompt you to enter `LIVEKIT_` variables manually (which can also be left empty).