### PR TITLE
fix(lk): fail early if config file is present and invalid

### DIFF
--- a/cmd/lk/agent.go
+++ b/cmd/lk/agent.go
@@ -254,9 +254,9 @@ func createAgentClient(ctx context.Context, cmd *cli.Command) (context.Context, 
 	}
 
 	// Verify that the project and agent config match, if it exists.
-	lkConfig, configExists, err := config.LoadTomlFile(workingDir, tomlFilename)
+	lkConfig, configExists, err := config.LoadTOMLFile(workingDir, tomlFilename)
 	if err != nil {
-		fmt.Println(err.Error())
+		return nil, err
 	}
 	if configExists {
 		projectSubdomainMatch := subdomainPattern.FindStringSubmatch(project.URL)
@@ -300,7 +300,7 @@ func createAgent(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	logger.Debugw("Creating agent", "working-dir", workingDir)
-	lkConfig, configExists, err := config.LoadTomlFile(workingDir, tomlFilename)
+	lkConfig, configExists, err := config.LoadTOMLFile(workingDir, tomlFilename)
 	if err != nil && configExists {
 		return err
 	}
@@ -500,8 +500,8 @@ func createAgentConfig(ctx context.Context, cmd *cli.Command) error {
 }
 
 func deployAgent(ctx context.Context, cmd *cli.Command) error {
-	lkConfig, configExists, err := config.LoadTomlFile(workingDir, tomlFilename)
-	if err != nil && configExists {
+	lkConfig, configExists, err := config.LoadTOMLFile(workingDir, tomlFilename)
+	if err != nil {
 		return err
 	}
 	if !configExists {
@@ -616,7 +616,7 @@ func getAgentStatus(ctx context.Context, cmd *cli.Command) error {
 }
 
 func updateAgent(ctx context.Context, cmd *cli.Command) error {
-	lkConfig, configExists, err := config.LoadTomlFile(workingDir, tomlFilename)
+	lkConfig, configExists, err := config.LoadTOMLFile(workingDir, tomlFilename)
 	if err != nil && configExists {
 		return err
 	}
@@ -901,7 +901,7 @@ func updateAgentSecrets(ctx context.Context, cmd *cli.Command) error {
 func getAgentName(cmd *cli.Command, agentDir string, tomlFileName string) (string, error) {
 	agentName := cmd.String("name")
 	if agentName == "" {
-		lkConfig, configExists, err := config.LoadTomlFile(agentDir, tomlFileName)
+		lkConfig, configExists, err := config.LoadTOMLFile(agentDir, tomlFileName)
 		if err != nil && configExists {
 			return "", err
 		}

--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -147,6 +147,9 @@ func requireProject(ctx context.Context, cmd *cli.Command) (context.Context, err
 		return ctx, nil
 	}
 	if project, err = loadProjectDetails(cmd); err != nil {
+		if errors.Is(err, config.ErrInvalidConfig) {
+			return ctx, err
+		}
 		if _, err = loadProjectConfig(ctx, cmd); err != nil {
 			// something is wrong with config file
 			return nil, err

--- a/cmd/lk/utils.go
+++ b/cmd/lk/utils.go
@@ -253,7 +253,10 @@ func loadProjectDetails(c *cli.Command, opts ...loadOption) (*config.ProjectConf
 	}
 
 	// load from config file
-	lkConfig, _, _ := config.LoadTomlFile(workingDir, tomlFilename)
+	lkConfig, _, err := config.LoadTOMLFile(workingDir, tomlFilename)
+	if errors.Is(err, config.ErrInvalidConfig) {
+		return nil, err
+	}
 	if lkConfig != nil {
 		return config.LoadProjectBySubdomain(lkConfig.Project.Subdomain)
 	}

--- a/pkg/agentfs/secrets-file.go
+++ b/pkg/agentfs/secrets-file.go
@@ -79,7 +79,7 @@ func DetectEnvFile(maybeFile string) (string, map[string]string, error) {
 		return "", nil, nil
 	}
 
-	var selectedFile string
+	var selectedFile string = extantEnvFiles[0]
 	if err := huh.NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().


### PR DESCRIPTION
Fixes an issue in #569 in which invalid config files were silently ignored