### PR TITLE
fix(agents): ux feedback

### DIFF
--- a/cmd/lk/agent.go
+++ b/cmd/lk/agent.go
@@ -253,9 +253,11 @@ func createAgentClient(ctx context.Context, cmd *cli.Command) (context.Context, 
 		workingDir = cmd.Args().First()
 	}
 
-	// Verify that the project and agent config match, if it exists.
+	// If a project has been manually selected that conflicts with the agent's config,
+	// or if the config file is malformed, this is an error. If the config does not exist,
+	// we assume it gets created later.
 	lkConfig, configExists, err := config.LoadTOMLFile(workingDir, tomlFilename)
-	if err != nil {
+	if !errors.Is(err, os.ErrNotExist) {
 		return nil, err
 	}
 	if configExists {
@@ -265,10 +267,6 @@ func createAgentClient(ctx context.Context, cmd *cli.Command) (context.Context, 
 		}
 		if projectSubdomainMatch[1] != lkConfig.Project.Subdomain {
 			return nil, fmt.Errorf("project does not match agent subdomain [%s]", lkConfig.Project.Subdomain)
-		}
-	} else {
-		if !errors.Is(err, os.ErrNotExist) {
-			return nil, err
 		}
 	}
 
@@ -295,8 +293,9 @@ func createAgent(ctx context.Context, cmd *cli.Command) error {
 			return err
 		}
 		if !useProject {
-			return fmt.Errorf("cancelled")
-
+			if _, err := selectProject(ctx, cmd); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -722,10 +721,22 @@ func deleteAgent(ctx context.Context, cmd *cli.Command) error {
 		return nil
 	}
 
-	resp, err := agentsClient.DeleteAgent(ctx, &lkproto.DeleteAgentRequest{
-		AgentName: agentName,
-	})
-	if err != nil {
+	var res *lkproto.DeleteAgentResponse
+	var innerErr error
+	if err := util.Await(
+		"Deleting agent ["+util.Accented(agentName)+"]",
+		func() {
+			if res, innerErr = agentsClient.DeleteAgent(ctx, &lkproto.DeleteAgentRequest{
+				AgentName: agentName,
+			}); err != nil {
+
+			}
+		},
+	); err != nil {
+		return err
+	}
+
+	if innerErr != nil {
 		if twerr, ok := err.(twirp.Error); ok {
 			if twerr.Code() == twirp.PermissionDenied {
 				return fmt.Errorf("agent hosting is disabled for this project -- join the beta program here [%s]", cloudAgentsBetaSignupURL)
@@ -734,8 +745,8 @@ func deleteAgent(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	if !resp.Success {
-		return fmt.Errorf("failed to delete agent %s", resp.Message)
+	if !res.Success {
+		return fmt.Errorf("failed to delete agent %s", res.Message)
 	}
 
 	fmt.Printf("Deleted agent [%s]\n", util.Accented(agentName))

--- a/cmd/lk/cloud.go
+++ b/cmd/lk/cloud.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/charmbracelet/huh"
-	"github.com/charmbracelet/huh/spinner"
 	"github.com/pkg/browser"
 	"github.com/urfave/cli/v3"
 
@@ -302,13 +301,12 @@ func tryAuthIfNeeded(ctx context.Context, cmd *cli.Command) error {
 
 	var ak *ClaimAccessKeyResponse
 	var pollErr error
-	if err := spinner.New().
-		Title("Awaiting confirmation...").
-		Action(func() {
+	if err := util.Await(
+		"Awaiting confirmation...",
+		func() {
 			ak, pollErr = pollClaim(ctx, cmd)
-		}).
-		Style(util.Theme.Focused.Title).
-		Run(); err != nil {
+		},
+	); err != nil {
 		return err
 	}
 	if pollErr != nil {

--- a/cmd/lk/utils.go
+++ b/cmd/lk/utils.go
@@ -192,7 +192,7 @@ func loadProjectDetails(c *cli.Command, opts ...loadOption) (*config.ProjectConf
 		if err != nil {
 			return nil, err
 		}
-		fmt.Println("Using project [" + util.Theme.Focused.Title.Render(c.String("project")) + "]")
+		fmt.Println("Using project [" + util.Accented(c.String("project")) + "]")
 		logDetails(c, pc)
 		return pc, nil
 	}
@@ -206,7 +206,7 @@ func loadProjectDetails(c *cli.Command, opts ...loadOption) (*config.ProjectConf
 		if err != nil {
 			return nil, err
 		}
-		fmt.Println("Using project [" + util.Theme.Focused.Title.Render(pc.Name) + "]")
+		fmt.Println("Using project [" + util.Accented(pc.Name) + "]")
 		logDetails(c, pc)
 		return pc, nil
 	}

--- a/pkg/util/action.go
+++ b/pkg/util/action.go
@@ -1,0 +1,28 @@
+// Copyright 2025 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"github.com/charmbracelet/huh/spinner"
+)
+
+// Call an action and show a spinner while waiting for it to finish.
+func Await(title string, action func()) error {
+	return spinner.New().
+		Title(title).
+		Action(action).
+		Style(Theme.Focused.Title).
+		Run()
+}


### PR DESCRIPTION
Implements some user experience feedback:

- Allow agent creation without secrets: `lk agent create` should continue if nothing in `--secrets` or `--secrets-file` and detected environment files are not used.
- If a default project is set but declined during `lk agent create`, we show the project picker instead of terminating
- Fix a bug in which `lk agent create` would fail erroneously if run without a selected project and no `livekit.toml` file exists