### PR TITLE
fix(ci): go version in dockerfile should match go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23-alpine as builder
+FROM golang:1.24-alpine as builder
 
 ARG TARGETPLATFORM
 ARG TARGETARCH

--- a/version.go
+++ b/version.go
@@ -15,5 +15,5 @@
 package livekitcli
 
 const (
-	Version = "2.4.7"
+	Version = "2.4.8"
 )


### PR DESCRIPTION
Docker deploy failing because go toolchain was bumped in `go.mod` but not in Dockerfile