### PR TITLE
fix(bootstrap): if not already, prompt to auth when bootstrapping sbx

### DIFF
--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -242,6 +242,10 @@ func setupTemplate(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	if isSandbox {
+		_, err := requireProject(ctx, cmd)
+		if err != nil {
+			return err
+		}
 		token, err := requireToken(ctx, cmd)
 		if err != nil {
 			return err


### PR DESCRIPTION
https://linear.app/livekit/issue/DEX-1617/prompt-to-authenticate-cli-when-bootstrapping-a-sandbox

If you try to bootstrap a project without first authenticating the CLI, we should push automatically to CLI auth flow instead of failing.