### PR TITLE
allow metadata to be passed for joining participant

### DIFF
--- a/cmd/lk/room.go
+++ b/cmd/lk/room.go
@@ -182,6 +182,10 @@ var (
 							Usage: "Automatically subscribe to published tracks.",
 							Value: false,
 						},
+						&cli.StringFlag{
+							Name:  "metadata",
+							Usage: "`JSON` metadata which will be passed to participant",
+						},
 					},
 				},
 				{
@@ -929,6 +933,7 @@ func joinRoom(ctx context.Context, cmd *cli.Command) error {
 		RoomName:              roomName,
 		ParticipantIdentity:   participantIdentity,
 		ParticipantAttributes: participantAttributes,
+		ParticipantMetadata:   cmd.String("metadata"),
 	}, roomCB, lksdk.WithAutoSubscribe(autoSubscribe))
 	if err != nil {
 		return err


### PR DESCRIPTION
This change allows `metadata` to be passed as part of `lk room join`.

See the related Slack thread here:
https://livekit-users.slack.com/archives/C025KM0S1CK/p1750953266259539