### PR TITLE
fix(agents+sip): address some style and usability issues

### DIFF
--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -171,7 +171,7 @@ func selectProject(ctx context.Context, cmd *cli.Command) (context.Context, erro
 	if cliConfig != nil && len(cliConfig.Projects) > 0 {
 		var options []huh.Option[*config.ProjectConfig]
 		for _, p := range cliConfig.Projects {
-			options = append(options, huh.NewOption(p.Name+" ["+util.ExtractSubdomain(p.URL)+"]", &p))
+			options = append(options, huh.NewOption(p.Name+" "+util.Dimmed(util.ExtractSubdomain(p.URL)), &p))
 		}
 		if err = huh.NewForm(
 			huh.NewGroup(huh.NewSelect[*config.ProjectConfig]().

--- a/cmd/lk/sip.go
+++ b/cmd/lk/sip.go
@@ -431,16 +431,16 @@ func listSetFlag(cmd *cli.Command, setName string) ([]string, bool) {
 	return val, true
 }
 
-func createSIPClient(cmd *cli.Command) (*lksdk.SIPClient, error) {
-	pc, err := loadProjectDetails(cmd)
+func createSIPClient(ctx context.Context, cmd *cli.Command) (*lksdk.SIPClient, error) {
+	_, err := requireProject(ctx, cmd)
 	if err != nil {
 		return nil, err
 	}
-	return lksdk.NewSIPClient(pc.URL, pc.APIKey, pc.APISecret, withDefaultClientOpts(pc)...), nil
+	return lksdk.NewSIPClient(project.URL, project.APIKey, project.APISecret, withDefaultClientOpts(project)...), nil
 }
 
 func createSIPInboundTrunk(ctx context.Context, cmd *cli.Command) error {
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -477,7 +477,7 @@ func createSIPInboundTrunk(ctx context.Context, cmd *cli.Command) error {
 }
 
 func updateSIPInboundTrunk(ctx context.Context, cmd *cli.Command) error {
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -539,7 +539,7 @@ func updateSIPInboundTrunk(ctx context.Context, cmd *cli.Command) error {
 }
 
 func createSIPOutboundTrunk(ctx context.Context, cmd *cli.Command) error {
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -593,7 +593,7 @@ func createSIPOutboundTrunk(ctx context.Context, cmd *cli.Command) error {
 }
 
 func updateSIPOutboundTrunk(ctx context.Context, cmd *cli.Command) error {
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -718,7 +718,7 @@ func printHeaderMaps(arr ...map[string]string) string {
 }
 
 func listSipTrunk(ctx context.Context, cmd *cli.Command) error {
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -743,7 +743,7 @@ func listSipTrunk(ctx context.Context, cmd *cli.Command) error {
 }
 
 func listSipInboundTrunk(ctx context.Context, cmd *cli.Command) error {
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -767,7 +767,7 @@ func listSipInboundTrunk(ctx context.Context, cmd *cli.Command) error {
 }
 
 func listSipOutboundTrunk(ctx context.Context, cmd *cli.Command) error {
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -793,7 +793,7 @@ func listSipOutboundTrunk(ctx context.Context, cmd *cli.Command) error {
 }
 
 func deleteSIPTrunk(ctx context.Context, cmd *cli.Command) error {
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -810,7 +810,7 @@ func deleteSIPTrunk(ctx context.Context, cmd *cli.Command) error {
 }
 
 func deleteSIPTrunkLegacy(ctx context.Context, cmd *cli.Command) error {
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -837,7 +837,7 @@ func printSIPOutboundTrunkID(info *livekit.SIPOutboundTrunkInfo) {
 }
 
 func createSIPDispatchRule(ctx context.Context, cmd *cli.Command) error {
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -894,7 +894,7 @@ func createSIPDispatchRule(ctx context.Context, cmd *cli.Command) error {
 }
 
 func createSIPDispatchRuleLegacy(ctx context.Context, cmd *cli.Command) error {
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -902,7 +902,7 @@ func createSIPDispatchRuleLegacy(ctx context.Context, cmd *cli.Command) error {
 }
 
 func updateSIPDispatchRule(ctx context.Context, cmd *cli.Command) error {
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -958,7 +958,7 @@ func updateSIPDispatchRule(ctx context.Context, cmd *cli.Command) error {
 }
 
 func listSipDispatchRule(ctx context.Context, cmd *cli.Command) error {
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -1002,7 +1002,7 @@ func listSipDispatchRule(ctx context.Context, cmd *cli.Command) error {
 }
 
 func deleteSIPDispatchRule(ctx context.Context, cmd *cli.Command) error {
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -1019,7 +1019,7 @@ func deleteSIPDispatchRule(ctx context.Context, cmd *cli.Command) error {
 }
 
 func deleteSIPDispatchRuleLegacy(ctx context.Context, cmd *cli.Command) error {
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -1038,7 +1038,7 @@ func printSIPDispatchRuleID(info *livekit.SIPDispatchRuleInfo) {
 }
 
 func createSIPParticipant(ctx context.Context, cmd *cli.Command) error {
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -1098,7 +1098,7 @@ func createSIPParticipant(ctx context.Context, cmd *cli.Command) error {
 }
 
 func createSIPParticipantLegacy(ctx context.Context, cmd *cli.Command) error {
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -1124,7 +1124,7 @@ func transferSIPParticipant(ctx context.Context, cmd *cli.Command) error {
 		PlayDialtone:        dialtone,
 	}
 
-	cli, err := createSIPClient(cmd)
+	cli, err := createSIPClient(ctx, cmd)
 	if err != nil {
 		return err
 	}

--- a/pkg/agentfs/utils.go
+++ b/pkg/agentfs/utils.go
@@ -37,15 +37,15 @@ func isNode(dir string) bool {
 	return false
 }
 
-func ParseCpu(cpu string) (float64, error) {
+func ParseCpu(cpu string) (string, error) {
 	cpuStr := strings.TrimSpace(cpu)
 	cpuQuantity, err := resource.ParseQuantity(cpuStr)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse CPU quantity: %v", err)
+		return "", fmt.Errorf("failed to parse CPU quantity: %v", err)
 	}
 
-	// Convert to whole CPU cores
-	cpuCores := float64(cpuQuantity.MilliValue()) / 1000
+	// Convert to millicores
+	cpuCores := fmt.Sprintf("%dm", cpuQuantity.MilliValue())
 
 	return cpuCores, nil
 }


### PR DESCRIPTION
- `lk sip` commands now work with automatic project auth flow if unauthenticated
- `lk agent list` and `lk agent versions` now sort entries by reverse-chronological order
```
> lk agent list
┌─────────────────┬─────────┬────────────────┬──────────────────────┐
│ ID              │ Regions │ Version        │ Deployed At          │
├─────────────────┼─────────┼────────────────┼──────────────────────┤
│ CA_xqxVnfLfH5sh │ us-east │ 20250723055127 │ 2025-07-23T05:51:30Z │
│ CA_JcXevr5Anw6Z │ us-east │ 20250718215738 │ 2025-07-18T21:57:39Z │
└─────────────────┴─────────┴────────────────┴──────────────────────┘
```
```
> lk agent versions
┌────────────────┬─────────┬──────────────────────┐
│ Version        │ Current │ Created At           │
├────────────────┼─────────┼──────────────────────┤
│ 20250723055127 │ true    │ 2025-07-23T05:51:30Z │
│ 20250723040906 │ false   │ 2025-07-23T04:09:07Z │
│ 20250722221041 │ false   │ 2025-07-22T22:10:44Z │
└────────────────┴─────────┴──────────────────────┘
```
- `lk agent status` now includes "Version" column and formats "CPU" in millicores
```
┌─────────────────┬────────────────┬─────────┬─────────┬────────┬───────────┬───────────┬──────────────────────┐
│ ID              │ Version        │ Region  │ Status  │ CPU    │ Mem       │ Replicas  │ Deployed At          │
├─────────────────┼────────────────┼─────────┼─────────┼────────┼───────────┼───────────┼──────────────────────┤
│ CA_JcXevr5Anw6Z │ 20250718215738 │ us-east │ Running │ 5m / 4 │ 1.7 / 8GB │ 1 / 1 / 8 │ 2025-07-18T21:57:39Z │
└─────────────────┴────────────────┴─────────┴─────────┴────────┴───────────┴───────────┴──────────────────────┘
```
- `lk agent` commands now open an agent picker whenever the `--id` field is required but omitted, making it easier to do things like check the status of an agent if you're not in the same working directory, and don't know its ID off the top of your head:


https://github.com/user-attachments/assets/f2544d4f-59c9-4087-a5ae-e67f073a72bf

