### PR TITLE
feat: add --disable-publish flag to load test commands

### DIFF
--- a/cmd/lk/perf.go
+++ b/cmd/lk/perf.go
@@ -78,6 +78,10 @@ var (
 							Usage: "Fire random speaker events to simulate speaker changes",
 						},
 						&cli.BoolFlag{
+							Name:  "disable-publish",
+							Usage: "Disable publishing permission for participants (canPublish: false)",
+						},
+						&cli.BoolFlag{
 							Name:   "run-all",
 							Usage:  "Runs set list of load test cases",
 							Hidden: true,
@@ -171,6 +175,10 @@ var (
 					Usage: "Fire random speaker events to simulate speaker changes",
 				},
 				&cli.BoolFlag{
+					Name:  "disable-publish",
+					Usage: "Disable publishing permission for participants (canPublish: false)",
+				},
+				&cli.BoolFlag{
 					Name:   "run-all",
 					Usage:  "Runs set list of load test cases",
 					Hidden: true,
@@ -198,6 +206,7 @@ func loadTest(ctx context.Context, cmd *cli.Command) error {
 		NumPerSecond:     cmd.Float("num-per-second"),
 		Simulcast:        !cmd.Bool("no-simulcast"),
 		SimulateSpeakers: cmd.Bool("simulate-speakers"),
+		CanPublish:       !cmd.Bool("disable-publish"), // if disable-publish is true, CanPublish becomes false
 		TesterParams: loadtester.TesterParams{
 			URL:            pc.URL,
 			APIKey:         pc.APIKey,
@@ -205,6 +214,7 @@ func loadTest(ctx context.Context, cmd *cli.Command) error {
 			Room:           cmd.String("room"),
 			IdentityPrefix: cmd.String("identity-prefix"),
 			Layout:         loadtester.LayoutFromString(cmd.String("layout")),
+			CanPublish:     !cmd.Bool("disable-publish"), // if disable-publish is true, CanPublish becomes false
 		},
 	}
 

--- a/pkg/loadtester/agentloadtester.go
+++ b/pkg/loadtester/agentloadtester.go
@@ -187,7 +187,7 @@ func (r *LoadTestRoom) start(roomName string) error {
 		return err
 	}
 
-	meetParticipantToken, _ := newAccessToken(r.params.APIKey, r.params.APISecret, roomName, "meet-participant")
+	meetParticipantToken, _ := newAgentAccessToken(r.params.APIKey, r.params.APISecret, roomName, "meet-participant")
 	r.stats.meetLink = fmt.Sprintf("https://meet.livekit.io/custom?liveKitUrl=%s&token=%s", r.params.URL, meetParticipantToken)
 	logger.Debugw("Inspect the room in LiveKit Meet using this url", "room", roomName, "url", r.stats.meetLink)
 	r.running.Store(true)
@@ -345,7 +345,7 @@ func (t *AgentLoadTester) printStats() {
 	fmt.Println(table)
 }
 
-func newAccessToken(apiKey, apiSecret, roomName, pID string) (string, error) {
+func newAgentAccessToken(apiKey, apiSecret, roomName, pID string) (string, error) {
 	at := auth.NewAccessToken(apiKey, apiSecret)
 	grant := &auth.VideoGrant{
 		RoomJoin: true,

--- a/pkg/loadtester/loadtest.go
+++ b/pkg/loadtester/loadtest.go
@@ -51,6 +51,8 @@ type Params struct {
 	NumPerSecond     float64
 	Simulcast        bool
 	SimulateSpeakers bool
+	// true to allow publishing tracks (default true)
+	CanPublish       bool
 
 	TesterParams
 }
@@ -308,6 +310,7 @@ func (t *LoadTest) run(ctx context.Context, params Params) (map[string]*testerSt
 		testerParams := params.TesterParams
 		testerParams.Sequence = i
 		testerParams.expectedTracks = expectedTracks
+		testerParams.CanPublish = params.CanPublish // Copy CanPublish from parent params
 		isVideoPublisher := i < params.VideoPublishers
 		isAudioPublisher := i < params.AudioPublishers
 		if isVideoPublisher || isAudioPublisher {


### PR DESCRIPTION
- Add CanPublish field to TesterParams and Params structs
- Add --disable-publish flag to both perf load-test and load-test commands
- Implement custom token generation with canPublish permission control
- Update LoadTester.Start() to use custom tokens when canPublish is false
- Maintain backward compatibility with existing behavior
- Rename conflicting newAccessToken in agentloadtester.go to newAgentAccessToken

This allows users to test scenarios where participants cannot publish tracks by setting canPublish: false in JWT tokens.