### PR TITLE
Ignore `.env.*` instead of `*.env` for cloud agents

### DIFF
--- a/pkg/agentfs/tar.go
+++ b/pkg/agentfs/tar.go
@@ -37,7 +37,7 @@ var (
 		".gitignore",
 		".git",
 		"node_modules",
-		"*.env",
+		".env.*",
 	}
 
 	ignoreFilePatterns = []string{

--- a/pkg/agentfs/tar_test.go
+++ b/pkg/agentfs/tar_test.go
@@ -150,7 +150,7 @@ func TestUploadTarballDotfiles(t *testing.T) {
 		path    string
 		content string
 	}{
-		{filepath.Join(tmpDir, ".gitignore"), "*.env\nnode_modules/"},
+		{filepath.Join(tmpDir, ".gitignore"), ".env.*\nnode_modules/"},
 		{filepath.Join(tmpDir, ".env"), "SECRET=123"},
 		{filepath.Join(tmpDir, ".config"), "config data"},
 		{filepath.Join(subDir, ".DS_Store"), "mac file"},


### PR DESCRIPTION
Ignore `.env.*` instead of `*.env` for cloud agents

Context: https://live-kit.slack.com/archives/C08HHUXHAKA/p1753727983216529?thread_ts=1753699955.554379&cid=C08HHUXHAKA