### PR TITLE
fix: make secrets and other kv arg parsing more rubust

### DIFF
--- a/cmd/lk/room.go
+++ b/cmd/lk/room.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"os/signal"
 	"regexp"
@@ -940,14 +941,9 @@ func joinRoom(ctx context.Context, cmd *cli.Command) error {
 		},
 	}
 
-	participantAttributes := make(map[string]string)
-
-	attrs := cmd.StringSlice("attribute")
-	for _, attr := range attrs {
-		kv := strings.Split(attr, "=")
-		if len(kv) == 2 {
-			participantAttributes[kv[0]] = kv[1]
-		}
+	participantAttributes, err := parseKeyValuePairs(cmd, "attributes")
+	if err != nil {
+		return fmt.Errorf("failed to parse participant attributes: %w", err)
 	}
 
 	// Read attributes from JSON file if specified
@@ -963,9 +959,7 @@ func joinRoom(ctx context.Context, cmd *cli.Command) error {
 		}
 
 		// Add attributes from file to the existing ones
-		for key, value := range fileAttrs {
-			participantAttributes[key] = value
-		}
+		maps.Copy(participantAttributes, fileAttrs)
 	}
 
 	room, err := lksdk.ConnectToRoom(project.URL, lksdk.ConnectInfo{

--- a/cmd/lk/room.go
+++ b/cmd/lk/room.go
@@ -941,7 +941,7 @@ func joinRoom(ctx context.Context, cmd *cli.Command) error {
 		},
 	}
 
-	participantAttributes, err := parseKeyValuePairs(cmd, "attributes")
+	participantAttributes, err := parseKeyValuePairs(cmd, "attribute")
 	if err != nil {
 		return fmt.Errorf("failed to parse participant attributes: %w", err)
 	}

--- a/cmd/lk/utils.go
+++ b/cmd/lk/utils.go
@@ -17,9 +17,11 @@ package main
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 
+	"github.com/joho/godotenv"
 	"github.com/twitchtv/twirp"
 	"github.com/urfave/cli/v3"
 
@@ -159,6 +161,24 @@ func extractFlagOrArg(c *cli.Command, flag string) (string, error) {
 		value = argValue
 	}
 	return value, nil
+}
+
+func parseKeyValuePairs(c *cli.Command, flag string) (map[string]string, error) {
+	pairs := c.StringSlice(flag)
+	if len(pairs) == 0 {
+		return nil, nil
+	}
+
+	result := make(map[string]string, len(pairs))
+
+	for _, pair := range pairs {
+		if m, err := godotenv.Unmarshal(pair); err != nil {
+			return nil, fmt.Errorf("invalid key-value pair: %s: %w", pair, err)
+		} else {
+			maps.Copy(result, m)
+		}
+	}
+	return result, nil
 }
 
 type loadParams struct {

--- a/pkg/agentfs/secrets-file.go
+++ b/pkg/agentfs/secrets-file.go
@@ -15,11 +15,10 @@
 package agentfs
 
 import (
-	"bufio"
 	"os"
-	"strings"
 
 	"github.com/charmbracelet/huh"
+	"github.com/joho/godotenv"
 	"github.com/livekit/livekit-cli/v2/pkg/util"
 )
 
@@ -33,33 +32,12 @@ var knownEnvFiles = []string{
 }
 
 func ParseEnvFile(file string) (map[string]string, error) {
-	env := make(map[string]string)
 	f, err := os.Open(file)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) < 2 {
-			continue
-		}
-
-		parts[0] = strings.TrimSpace(parts[0])
-		parts[1] = strings.TrimSpace(parts[1])
-		parts[1] = strings.Trim(parts[1], "\"'")
-		parts[1] = strings.Split(parts[1], "#")[0]
-		env[parts[0]] = parts[1]
-	}
-
-	return env, nil
+	return godotenv.Parse(f)
 }
 
 func DetectEnvFile(maybeFile string) (string, map[string]string, error) {


### PR DESCRIPTION
https://linear.app/livekit/issue/HA-243/fix-secrets-parsing-when-encountering-special-characters-in-secret

Improve parsing of `--secrets` flag (and other `StringSlice`-based key-value arguments) by parsing them properly with `godotenv`. Previously we used a naive method of splitting on "=" character, but this is insufficient for things like base64 encoded secrets, inline TOML, and anything with that character as part of a secret.

A downside of this approach is that we can no longer use built-in CSV splitting, so a command like this:

```
lk agent update-secrets --secrets 'foo=yes,bar=42'
```

Now has to be passed as multiple arguments:

```
lk agent update-secrets \
  --secrets 'foo=yes' \
  --secrets 'bar=42'
```

An upside is that we can support inline JSON:

```
lk agent update-secrets  --secrets 'foo={"a":"b","c":"d"}'
```