### PR TITLE
chore: better copy when authenticating a project with same name

### DIFF
--- a/cmd/lk/cloud.go
+++ b/cmd/lk/cloud.go
@@ -333,7 +333,8 @@ func tryAuthIfNeeded(ctx context.Context, cmd *cli.Command) error {
 	}
 	if cliConfig.ProjectExists(name) {
 		if err := huh.NewInput().
-			Title("Project name already exists, please choose a different name").
+			Title("Choose a different alias").
+			Description(fmt.Sprintf("You've already configured a project with the alias %q.", name)).
 			Value(&name).
 			Validate(func(s string) error {
 				if cliConfig.ProjectExists(s) {


### PR DESCRIPTION
https://linear.app/livekit/issue/HA-172/improve-clarity-of-project-name-conflict-message-in-lk-cloud-cli