### PR TITLE
chore(agents): fallback to agent selector when generating config

### DIFF
--- a/cmd/lk/agent.go
+++ b/cmd/lk/agent.go
@@ -518,7 +518,7 @@ func createAgentConfig(ctx context.Context, cmd *cli.Command) error {
 		Regions: regions,
 	}
 
-	if err := lkConfig.SaveTOMLFile("", tomlFilename); err != nil {
+	if err := lkConfig.SaveTOMLFile(workingDir, tomlFilename); err != nil {
 		return err
 	}
 	return nil

--- a/version.go
+++ b/version.go
@@ -15,5 +15,5 @@
 package livekitcli
 
 const (
-	Version = "2.4.15"
+	Version = "2.5.0"
 )


### PR DESCRIPTION
- Allow user to select existing Agent ID if not provided in `lk agent config`
- Respects `workingDir` when creating config file
- Bump version