### PR TITLE
fix(agents): correctly expand `PROGRAM_MAIN` in Dockerfiles

### DIFF
--- a/pkg/agentfs/examples/python.pip.Dockerfile
+++ b/pkg/agentfs/examples/python.pip.Dockerfile
@@ -7,8 +7,8 @@ FROM python:${PYTHON_VERSION}-slim
 # the application crashes without emitting any logs due to buffering.
 ENV PYTHONUNBUFFERED=1
 
-# Define the program entrypoint file where your agent is started
-ARG PROGRAM_MAIN="src/agent.py"
+# Define the program entrypoint file where your agent is started.
+ARG PROGRAM_MAIN="{{.ProgramMain}}"
 
 # Create a non-privileged user that the app will run under.
 # See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
@@ -48,5 +48,5 @@ RUN python "$PROGRAM_MAIN" download-files
 EXPOSE 8081
 
 # Run the application.
-CMD ["python", "$PROGRAM_MAIN", "start"]
-
+# The "start" command tells the worker to connect to LiveKit and begin waiting for jobs.
+CMD ["python", "{{.ProgramMain}}", "start"]

--- a/pkg/agentfs/examples/python.uv.Dockerfile
+++ b/pkg/agentfs/examples/python.uv.Dockerfile
@@ -10,8 +10,8 @@ FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
 # the application crashes without emitting any logs due to buffering.
 ENV PYTHONUNBUFFERED=1
 
-# Define the program entrypoint file where your agent is started
-ARG PROGRAM_MAIN="src/agent.py"
+# Define the program entrypoint file where your agent is started.
+ARG PROGRAM_MAIN="{{.ProgramMain}}"
 
 # Create a non-privileged user that the app will run under.
 # See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
@@ -71,7 +71,7 @@ RUN uv run "$PROGRAM_MAIN" download-files
 EXPOSE 8081
 
 # Run the application using UV
-# UV will activate the virtual environment and run the agent
-# The "start" command tells the worker to connect to LiveKit and begin waiting for jobs
-CMD ["uv", "run", "$PROGRAM_MAIN", "start"]
+# UV will activate the virtual environment and run the agent.
+# The "start" command tells the worker to connect to LiveKit and begin waiting for jobs.
+CMD ["uv", "run", "{{.ProgramMain}}", "start"]
 


### PR DESCRIPTION
Fix expansion of the `PROGRAM_MAIN` variable in python Dockerfile templates by using native Golang string templates. This vastly simplifies the previous entrypoint detection we were doing previously.

Have tested this with both a `pip` and `uv` project locally, as well as with cloud deployments and it works 👍 