### PR TITLE
Add generate dockerfile command

### DIFF
--- a/cmd/lk/agent.go
+++ b/cmd/lk/agent.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -110,6 +111,22 @@ var (
 					// we disable it entirely here and require multiple --secrets flags to be used.
 					DisableSliceFlagSeparator: true,
 					ArgsUsage:                 "[working-dir]",
+				},
+				{
+					Name:   "dockerfile",
+					Usage:  "Generate Dockerfile and .dockerignore for your project",
+					Before: createAgentClient,
+					Action: generateAgentDockerfile,
+					Flags: []cli.Flag{
+						silentFlag,
+						&cli.BoolFlag{
+							Name:     "overwrite",
+							Usage:    "Overwrite existing Dockerfile and/or .dockerignore if they exist",
+							Required: false,
+							Value:    false,
+						},
+					},
+					ArgsUsage: "[working-dir]",
 				},
 				{
 					Name:   "config",
@@ -378,6 +395,7 @@ func createAgent(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	projectType, err := agentfs.DetectProjectType(workingDir)
+	fmt.Printf("Detected project type [%s]\n", util.Accented(string(projectType)))
 	if err != nil {
 		return fmt.Errorf("unable to determine project type: %w, please use a supported project type, or create your own Dockerfile in the current directory", err)
 	}
@@ -1212,4 +1230,70 @@ func requireConfig(workingDir, tomlFilename string) (bool, error) {
 	var err error
 	lkConfig, exists, err = config.LoadTOMLFile(workingDir, tomlFilename)
 	return exists, err
+}
+
+func generateAgentDockerfile(ctx context.Context, cmd *cli.Command) error {
+	if cmd.NArg() > 0 {
+		workingDir = cmd.Args().First()
+	}
+
+	if stat, err := os.Stat(workingDir); err != nil || !stat.IsDir() {
+		return fmt.Errorf("invalid working directory: %s", workingDir)
+	}
+
+	settingsMap, err := getClientSettings(ctx, cmd.Bool("silent"))
+	if err != nil {
+		return err
+	}
+
+	projectType, err := agentfs.DetectProjectType(workingDir)
+	fmt.Printf("Detected project type [%s]\n", util.Accented(string(projectType)))
+	if err != nil {
+		return fmt.Errorf("unable to determine project type: %w, please use a supported project type, or create your own Dockerfile in the current directory", err)
+	}
+
+	dockerfilePath := filepath.Join(workingDir, "Dockerfile")
+	dockerignorePath := filepath.Join(workingDir, ".dockerignore")
+	overwrite := cmd.Bool("overwrite")
+
+	writeDockerfile := true
+	writeDockerignore := true
+	if !overwrite {
+		if _, err := os.Stat(dockerfilePath); err == nil {
+			fmt.Println("Dockerfile already exists; skipping. Use --overwrite to replace.")
+			writeDockerfile = false
+		}
+		if _, err := os.Stat(dockerignorePath); err == nil {
+			fmt.Println(".dockerignore already exists; skipping. Use --overwrite to replace.")
+			writeDockerignore = false
+		}
+	}
+
+	if !writeDockerfile && !writeDockerignore {
+		fmt.Println("No files to write.")
+		return nil
+	}
+
+	// Generate contents without writing
+	dockerfileContent, dockerignoreContent, err := agentfs.GenerateDockerArtifacts(workingDir, projectType, settingsMap)
+	if err != nil {
+		return err
+	}
+
+	if writeDockerfile {
+		if err := os.WriteFile(dockerfilePath, dockerfileContent, 0644); err != nil {
+			return err
+		}
+
+		fmt.Printf("Wrote %s\n", util.Accented("Dockerfile"))
+	}
+
+	if writeDockerignore {
+		if err := os.WriteFile(dockerignorePath, dockerignoreContent, 0644); err != nil {
+			return err
+		}
+		fmt.Printf("Wrote %s\n", util.Accented(".dockerignore"))
+	}
+
+	return nil
 }

--- a/cmd/lk/agent.go
+++ b/cmd/lk/agent.go
@@ -1260,17 +1260,16 @@ func generateAgentDockerfile(ctx context.Context, cmd *cli.Command) error {
 	writeDockerignore := true
 	if !overwrite {
 		if _, err := os.Stat(dockerfilePath); err == nil {
-			fmt.Println("Dockerfile already exists; skipping. Use --overwrite to replace.")
+			fmt.Println(util.Accented("Dockerfile") + " already exists; skipping. Use --overwrite to replace.")
 			writeDockerfile = false
 		}
 		if _, err := os.Stat(dockerignorePath); err == nil {
-			fmt.Println(".dockerignore already exists; skipping. Use --overwrite to replace.")
+			fmt.Println(util.Accented(".dockerignore") + " already exists; skipping. Use --overwrite to replace.")
 			writeDockerignore = false
 		}
 	}
 
 	if !writeDockerfile && !writeDockerignore {
-		fmt.Println("No files to write.")
 		return nil
 	}
 
@@ -1285,14 +1284,14 @@ func generateAgentDockerfile(ctx context.Context, cmd *cli.Command) error {
 			return err
 		}
 
-		fmt.Printf("Wrote %s\n", util.Accented("Dockerfile"))
+		fmt.Printf("Wrote new %s\n", util.Accented("Dockerfile"))
 	}
 
 	if writeDockerignore {
 		if err := os.WriteFile(dockerignorePath, dockerignoreContent, 0644); err != nil {
 			return err
 		}
-		fmt.Printf("Wrote %s\n", util.Accented(".dockerignore"))
+		fmt.Printf("Wrote new %s\n", util.Accented(".dockerignore"))
 	}
 
 	return nil

--- a/pkg/agentfs/docker.go
+++ b/pkg/agentfs/docker.go
@@ -122,8 +122,9 @@ func validateEntrypoint(dir string, dockerfileContent []byte, dockerignoreConten
 				return err
 			}
 			if !d.IsDir() && strings.HasSuffix(d.Name(), projectType.FileExt()) {
-				// Exclude files like __init__.py which cannot be entrypoints
-				if d.Name() == "__init__.py" {
+				// Exclude double-underscore files (e.g., __init__.py) which cannot be entrypoint
+				// except for __main__.py, which is the default entrypoint for Python.
+				if strings.HasPrefix(d.Name(), "__") && d.Name() != "__main__.py" {
 					return nil
 				}
 				fileList = append(fileList, path)

--- a/pkg/agentfs/utils.go
+++ b/pkg/agentfs/utils.go
@@ -171,12 +171,3 @@ func ParseMem(mem string, suffix bool) (string, error) {
 	}
 	return fmt.Sprintf("%.2g", memGB), nil
 }
-
-func validateSettingsMap(settingsMap map[string]string, keys []string) error {
-	for _, key := range keys {
-		if _, ok := settingsMap[key]; !ok {
-			return fmt.Errorf("client setting %s is required, please try again later", key)
-		}
-	}
-	return nil
-}


### PR DESCRIPTION
While testing #646 I made a couple updates that deserved their own PR

- [x] Add a `lk agent dockerfile` command to make new dockerfiles without making agents
- [x] Fix python entrypoint detection to ignore `__init__.py` files and also ensure agent.py/main.py are listed first
- [x] Add a little more output to the commands to tell you about the files being created and the project type detection used

<img width="790" height="107" alt="image" src="https://github.com/user-attachments/assets/ed5714bd-e07b-4c65-bce5-28d21ceb00b0" />
