### PR TITLE
Add stress-test benchmark to connect a livekit server for multiple rooms

### DIFF
--- a/pkg/loadtester/loadtester.go
+++ b/pkg/loadtester/loadtester.go
@@ -79,6 +79,7 @@ type TesterParams struct {
 	APIKey         string
 	APISecret      string
 	Room           string
+	RoomPrefix     string
 	IdentityPrefix string
 	Layout         Layout
 	// true to subscribe to all published tracks
@@ -152,7 +153,7 @@ func (t *LoadTester) PublishAudioTrack(name string) (string, error) {
 		return "", nil
 	}
 
-	fmt.Println("publishing audio track -", t.room.LocalParticipant.Identity())
+	fmt.Println("publishing room ", t.room.Name(), "audio track -", t.room.LocalParticipant.Identity())
 	audioLooper, err := provider2.CreateAudioLooper()
 	if err != nil {
 		return "", err
@@ -179,7 +180,7 @@ func (t *LoadTester) PublishVideoTrack(name, resolution, codec string) (string, 
 		return "", nil
 	}
 
-	fmt.Println("publishing video track -", t.room.LocalParticipant.Identity())
+	fmt.Println("publishing room ", t.room.Name(), " video track -", t.room.LocalParticipant.Identity())
 	loopers, err := provider2.CreateVideoLoopers(resolution, codec, false)
 	if err != nil {
 		return "", err
@@ -204,7 +205,7 @@ func (t *LoadTester) PublishVideoTrack(name, resolution, codec string) (string, 
 func (t *LoadTester) PublishSimulcastTrack(name, resolution, codec string) (string, error) {
 	var tracks []*lksdk.LocalTrack
 
-	fmt.Println("publishing simulcast video track -", t.room.LocalParticipant.Identity())
+	fmt.Println("publishing room ", t.room.Name(), " simulcast video track -", t.room.LocalParticipant.Identity())
 	loopers, err := provider2.CreateVideoLoopers(resolution, codec, true)
 	if err != nil {
 		return "", err
@@ -317,7 +318,7 @@ func (t *LoadTester) onTrackSubscribed(track *webrtc.TrackRemote, pub *lksdk.Rem
 		kind:    pub.Kind(),
 	}
 	t.stats.Store(track.ID(), s)
-	fmt.Println("subscribed to track", t.room.LocalParticipant.Identity(), pub.SID(), pub.Kind(), fmt.Sprintf("%d/%d", numSubscribed, numTotal))
+	fmt.Println("subscribed to room ", t.room.Name(), " - track", t.room.LocalParticipant.Identity(), pub.SID(), pub.Kind(), fmt.Sprintf("%d/%d", numSubscribed, numTotal))
 
 	// consume track
 	go t.consumeTrack(track, pub, rp)


### PR DESCRIPTION
how to use:
**`lk stress-test --rooms 5 --video-publishers 2  --audio-publishers 2 --subscribers 2 --duration 1m`**

log output:
```
Room summaries:
┌─────────┬────────┬──────────────────────────┬─────────────────┬───────┐
│ Room    │ Tracks │ Bitrate                  │ Total Pkt. Loss │ Error │
├─────────┼────────┼──────────────────────────┼─────────────────┼───────┤
│ plzom_1 │ 8/8    │ 4.0mbps (2.0mbps avg)    │ 0 (0%)          │       │
│ plzom_4 │ 8/8    │ 5.0mbps (2.5mbps avg)    │ 0 (0%)          │       │
│ plzom_3 │ 8/8    │ 4.4mbps (2.2mbps avg)    │ 0 (0%)          │       │
│ plzom_0 │ 8/8    │ 5.0mbps (2.5mbps avg)    │ 0 (0%)          │       │
│ plzom_2 │ 8/8    │ 4.4mbps (2.2mbps avg)    │ 0 (0%)          │       │
│ Total   │ 40/40  │ 22.8mbps (911.6kbps avg) │ 0 (0%)          │       │
└─────────┴────────┴──────────────────────────┴─────────────────┴───────┘
```

Output log breaking changes:
```
publishing audio track - yleor_pub_1   -->  publishing room  plzom_3 audio track -  yleor_pub_1
publishing simulcast video track - jybls_pub_1  -->  publishing room  plzom_3  simulcast video track - jybls_pub_1
publishing video track - jybls_pub_1
Finished connecting to room, waiting 1m0s  -->  Finished connecting to room plzom_4, waiting 1m0s
subscribed to track walwt_2 TR_VCjj77AvcwDdrX video 1/2 -->  subscribed to room  plzom_4  - track TR_VCjj77AvcwDdrX video 1/2
```