### PR TITLE
feat(projects): start storing ID on project credentials

### DIFF
--- a/cmd/lk/cloud.go
+++ b/cmd/lk/cloud.go
@@ -271,6 +271,7 @@ func tryAuthIfNeeded(ctx context.Context, cmd *cli.Command) error {
 	// get devicename
 	if err := huh.NewInput().
 		Title("What is the name of this device?").
+		Description("A short name you can use to find and manage generated API keys on the LiveKit Cloud dashboard").
 		Value(&cliConfig.DeviceName).
 		WithTheme(util.Theme).
 		Run(); err != nil {
@@ -352,6 +353,7 @@ func tryAuthIfNeeded(ctx context.Context, cmd *cli.Command) error {
 	// persist to config file
 	cliConfig.Projects = append(cliConfig.Projects, config.ProjectConfig{
 		Name:      name,
+		ProjectId: ak.ProjectId,
 		APIKey:    ak.Key,
 		APISecret: ak.Secret,
 		URL:       ak.URL,

--- a/cmd/lk/project.go
+++ b/cmd/lk/project.go
@@ -262,7 +262,7 @@ func listProjects(ctx context.Context, cmd *cli.Command) error {
 					return baseStyle
 				}
 			}).
-			Headers("Name", "URL", "API Key")
+			Headers("Name", "ID", "URL", "API Key")
 		for _, p := range cliConfig.Projects {
 			var pName string
 			if p.Name == cliConfig.DefaultProject {
@@ -270,7 +270,11 @@ func listProjects(ctx context.Context, cmd *cli.Command) error {
 			} else {
 				pName = "  " + p.Name
 			}
-			table.Row(pName, p.URL, p.APIKey)
+			pID := p.ProjectId
+			if pID == "" {
+				pID = "-"
+			}
+			table.Row(pName, pID, p.URL, p.APIKey)
 		}
 		fmt.Println(table)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,7 @@ type CLIConfig struct {
 
 type ProjectConfig struct {
 	Name      string `yaml:"name"`
+	ProjectId string `yaml:"id"`
 	URL       string `yaml:"url"`
 	APIKey    string `yaml:"api_key"`
 	APISecret string `yaml:"api_secret"`


### PR DESCRIPTION
https://linear.app/livekit/issue/DPRO-461/save-project-id-in-cli-credentials

- Begins saving project ID on credentials when authenticating
- Adds ability to specify a specific project to auth with `lk cloud auth <project_id>`, which when backend support is added, will let us pre-select (and automatically confirm) project to authenticate.