### PR TITLE
chore: update to Python 3.13 in default Docker templates

### DIFF
--- a/pkg/agentfs/examples/python.pip.Dockerfile
+++ b/pkg/agentfs/examples/python.pip.Dockerfile
@@ -2,9 +2,9 @@
 # For more information on the build process, see https://docs.livekit.io/agents/ops/deployment/builds/
 # syntax=docker/dockerfile:1
 
-# Use the official Python base image with Python 3.11
+# Use the official Python base image with Python 3.13
 # We use the slim variant to keep the image size smaller while still having essential tools
-ARG PYTHON_VERSION=3.11
+ARG PYTHON_VERSION=3.13
 FROM python:${PYTHON_VERSION}-slim AS base
 
 # Keeps Python from buffering stdout and stderr to avoid situations where

--- a/pkg/agentfs/examples/python.uv.Dockerfile
+++ b/pkg/agentfs/examples/python.uv.Dockerfile
@@ -2,10 +2,10 @@
 # For more information on the build process, see https://docs.livekit.io/agents/ops/deployment/builds/
 # syntax=docker/dockerfile:1
 
-# Use the official UV Python base image with Python 3.11 on Debian Bookworm
+# Use the official UV Python base image with Python 3.13 on Debian Bookworm
 # UV is a fast Python package manager that provides better performance than pip
 # We use the slim variant to keep the image size smaller while still having essential tools
-ARG PYTHON_VERSION=3.11
+ARG PYTHON_VERSION=3.13
 FROM ghcr.io/astral-sh/uv:python${PYTHON_VERSION}-bookworm-slim AS base
 
 # Keeps Python from buffering stdout and stderr to avoid situations where


### PR DESCRIPTION
some Agents extra dependencies (like aws realtime) require Python 3.12+ we shouldn't need to ship with older versions of Python