### PR TITLE
fix(agents): convert agent entrypoints to unix path before templating

### DIFF
--- a/pkg/agentfs/docker.go
+++ b/pkg/agentfs/docker.go
@@ -83,12 +83,9 @@ func GenerateDockerArtifacts(dir string, projectType ProjectType, settingsMap ma
 		return nil, nil, err
 	}
 
-	// TODO: (@rektdeckard) support Node entrypoint validation
-	if projectType.IsPython() {
-		dockerfileContent, err = validateEntrypoint(dir, dockerfileContent, dockerIgnoreContent, projectType)
-		if err != nil {
-			return nil, nil, err
-		}
+	dockerfileContent, err = validateEntrypoint(dir, dockerfileContent, dockerIgnoreContent, projectType)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	return dockerfileContent, dockerIgnoreContent, nil
@@ -134,11 +131,11 @@ func validateEntrypoint(dir string, dockerfileContent []byte, dockerignoreConten
 		priority := func(p string) int {
 			name := filepath.Base(p)
 			switch name {
-			case "__main__.py":
+			case "__main__.py", "index.js":
 				return 0
-			case "main.py":
+			case "main.py", "main.js":
 				return 1
-			case "agent.py":
+			case "agent.py", "agent.js":
 				return 2
 			default:
 				return 3
@@ -156,7 +153,7 @@ func validateEntrypoint(dir string, dockerfileContent []byte, dockerignoreConten
 
 	var newEntrypoint string
 	if len(fileList) == 0 {
-		newEntrypoint = "main.py"
+		newEntrypoint = projectType.DefaultEntrypoint()
 	} else if len(fileList) == 1 {
 		newEntrypoint = fileList[0]
 	} else {

--- a/pkg/agentfs/docker.go
+++ b/pkg/agentfs/docker.go
@@ -173,7 +173,7 @@ func validateEntrypoint(dir string, dockerfileContent []byte, dockerignoreConten
 		if err := form.Run(); err != nil {
 			return nil, err
 		}
-		newEntrypoint = selected
+		newEntrypoint = util.ToUnixPath(selected)
 	}
 
 	fmt.Printf("Using entrypoint file [%s]\n", util.Accented(newEntrypoint))

--- a/pkg/agentfs/tar.go
+++ b/pkg/agentfs/tar.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/schollz/progressbar/v3"
 
+	"github.com/livekit/livekit-cli/v2/pkg/util"
 	"github.com/livekit/protocol/logger"
 )
 
@@ -218,7 +219,7 @@ func UploadTarball(directory string, presignedUrl string, excludeFiles []string)
 		if err != nil {
 			return fmt.Errorf("failed to create tar header for file %s: %w", path, err)
 		}
-		header.Name = relPath
+		header.Name = util.ToUnixPath(relPath)
 		if err := tarWriter.WriteHeader(header); err != nil {
 			return fmt.Errorf("failed to write tar header for file %s: %w", path, err)
 		}

--- a/pkg/agentfs/utils.go
+++ b/pkg/agentfs/utils.go
@@ -65,6 +65,17 @@ func (p ProjectType) FileExt() string {
 	}
 }
 
+func (p ProjectType) DefaultEntrypoint() string {
+	switch {
+	case p.IsPython():
+		return "agent.py"
+	case p.IsNode():
+		return "agent.js"
+	default:
+		return ""
+	}
+}
+
 func LocateLockfile(dir string, p ProjectType) (bool, string) {
 	pythonFiles := []string{
 		"requirements.txt",

--- a/pkg/util/fs.go
+++ b/pkg/util/fs.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/livekit/protocol/utils/guid"
 )
@@ -119,4 +120,10 @@ func UseTempPath(permanentPath string) (string, func() error, func() error) {
 		return nil
 	}
 	return tempPath, relocate, cleanup
+}
+
+// Converts a path (possibly Windows-style) to a Unix-style path.
+func ToUnixPath(p string) string {
+	clean := filepath.Clean(p)
+	return strings.ReplaceAll(clean, `\`, `/`)
 }

--- a/version.go
+++ b/version.go
@@ -15,5 +15,5 @@
 package livekitcli
 
 const (
-	Version = "2.5.1"
+	Version = "2.5.2"
 )


### PR DESCRIPTION
https://linear.app/livekit/issue/HA-270/make-sure-file-paths-in-agent-commands-account-for-os-specific-path

Detected agent entrypoint should always be normalized to a Unix path before inserting into Dockerfile template.
So should the relative paths of files appended to tarball during upload.