### PR TITLE
Fix broken python builds

### DIFF
--- a/version.go
+++ b/version.go
@@ -15,5 +15,5 @@
 package livekitcli
 
 const (
-	Version = "2.5.3"
+	Version = "2.5.4"
 )


### PR DESCRIPTION
I accidentally committed some work in https://github.com/livekit/livekit-cli/pull/661 that was not meant to be committed, but I didn't notice while rushing to get the 1.0 node support out.  that stuff broke python builds due to overwriting the server venv