### PR TITLE
fix dockerignore and tarball uploads for cloud agents

### DIFF
--- a/cmd/lk/agent.go
+++ b/cmd/lk/agent.go
@@ -432,7 +432,7 @@ func createAgent(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	err = agentfs.UploadTarball(workingDir, resp.PresignedUrl, []string{config.LiveKitTOMLFile})
+	err = agentfs.UploadTarball(workingDir, resp.PresignedUrl, []string{fmt.Sprintf("**/%s", config.LiveKitTOMLFile)}, projectType)
 	if err != nil {
 		return err
 	}
@@ -595,7 +595,7 @@ func deployAgent(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	presignedUrl := resp.PresignedUrl
-	err = agentfs.UploadTarball(workingDir, presignedUrl, []string{config.LiveKitTOMLFile})
+	err = agentfs.UploadTarball(workingDir, presignedUrl, []string{fmt.Sprintf("**/%s", config.LiveKitTOMLFile)}, projectType)
 	if err != nil {
 		return err
 	}

--- a/pkg/agentfs/docker.go
+++ b/pkg/agentfs/docker.go
@@ -73,12 +73,12 @@ func GenerateDockerArtifacts(dir string, projectType ProjectType, settingsMap ma
 		return nil, nil, fmt.Errorf("unable to fetch client settings from server, please try again later")
 	}
 
-	dockerfileContent, err := fs.ReadFile("examples/" + string(projectType) + ".Dockerfile")
+	dockerfileContent, err := fs.ReadFile(filepath.Join("examples", string(projectType)+".Dockerfile"))
 	if err != nil {
 		return nil, nil, err
 	}
 
-	dockerIgnoreContent, err := fs.ReadFile("examples/" + string(projectType) + ".dockerignore")
+	dockerIgnoreContent, err := fs.ReadFile(filepath.Join("examples", string(projectType)+".dockerignore"))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/agentfs/examples/node.dockerignore
+++ b/pkg/agentfs/examples/node.dockerignore
@@ -1,25 +1,25 @@
 # Node.js dependencies
-node_modules
-npm-debug.log
-yarn-error.log
-pnpm-debug.log
+**/node_modules
+**/npm-debug.log
+**/yarn-error.log
+**/pnpm-debug.log
 
 # Build outputs
-dist
-build
-coverage
+**/dist
+**/build
+**/coverage
 
 # Local environment & config files
-.env
-.env.local
+**/.env
+**/.env.local
 .DS_Store
 
 # Logs & temp files
-*.log
-*.gz
-*.tgz
-.tmp
-.cache
+**/*.log
+**/*.gz
+**/*.tgz
+**/.tmp
+**/.cache
 
 # Docker artifacts
 Dockerfile*

--- a/pkg/agentfs/examples/python.pip.dockerignore
+++ b/pkg/agentfs/examples/python.pip.dockerignore
@@ -1,32 +1,32 @@
 # Python bytecode and artifacts
-__pycache__/
-*.py[cod]
-*.pyo
-*.pyd
-*.egg-info/
-dist/
-build/
+**/__pycache__/
+**/*.py[cod]
+**/*.pyo
+**/*.pyd
+**/*.egg-info/
+**/dist/
+**/build/
 
 # Virtual environments
-.venv/
-venv/
+**/.venv/
+**/venv/
 
 # Caches and test output
-.cache/
-.pytest_cache/
-.ruff_cache/
-coverage/
+**/.cache/
+**/.pytest_cache/
+**/.ruff_cache/
+**/coverage/
 
 # Logs and temp files
-*.log
-*.gz
-*.tgz
-.tmp
-.cache
+**/*.log
+**/*.gz
+**/*.tgz
+**/.tmp
+**/.cache
 
 # Environment variables
-.env
-.env.*
+**/.env
+**/.env.*
 
 # VCS, editor, OS
 .git

--- a/pkg/agentfs/examples/python.uv.dockerignore
+++ b/pkg/agentfs/examples/python.uv.dockerignore
@@ -1,32 +1,32 @@
 # Python bytecode and artifacts
-__pycache__/
-*.py[cod]
-*.pyo
-*.pyd
-*.egg-info/
-dist/
-build/
+**/__pycache__/
+**/*.py[cod]
+**/*.pyo
+**/*.pyd
+**/*.egg-info/
+**/dist/
+**/build/
 
 # Virtual environments
-.venv/
-venv/
+**/.venv/
+**/venv/
 
 # Caches and test output
-.cache/
-.pytest_cache/
-.ruff_cache/
-coverage/
+**/.cache/
+**/.pytest_cache/
+**/.ruff_cache/
+**/coverage/
 
 # Logs and temp files
-*.log
-*.gz
-*.tgz
-.tmp
-.cache
+**/*.log
+**/*.gz
+**/*.tgz
+**/.tmp
+**/.cache
 
 # Environment variables
-.env
-.env.*
+**/.env
+**/.env.*
 
 # VCS, editor, OS
 .git

--- a/pkg/agentfs/tar.go
+++ b/pkg/agentfs/tar.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/livekit/livekit-cli/v2/pkg/util"
 	"github.com/livekit/protocol/logger"
+
+	"github.com/moby/patternmatcher"
 )
 
 var (
@@ -48,26 +50,65 @@ var (
 	}
 )
 
-func UploadTarball(directory string, presignedUrl string, excludeFiles []string) error {
-	excludeFiles = append(defaultExcludePatterns, excludeFiles...)
+func UploadTarball(directory string, presignedUrl string, excludeFiles []string, projectType ProjectType) error {
+	excludeFiles = append(excludeFiles, defaultExcludePatterns...)
 
-	for _, exclude := range ignoreFilePatterns {
-		ignore := filepath.Join(directory, exclude)
-		if _, err := os.Stat(ignore); err == nil {
-			content, err := os.ReadFile(ignore)
+	loadExcludeFiles := func(filename string) (bool, string, error) {
+		if _, err := os.Stat(filename); err == nil {
+			content, err := os.ReadFile(filename)
 			if err != nil {
-				return fmt.Errorf("failed to read %s: %w", ignore, err)
+				return false, "", err
 			}
-			excludeFiles = append(excludeFiles, strings.Split(string(content), "\n")...)
+			return true, string(content), nil
 		}
+		return false, "", nil
+	}
+
+	foundDockerIgnore := false
+	for _, exclude := range ignoreFilePatterns {
+		found, content, err := loadExcludeFiles(filepath.Join(directory, exclude))
+		if err != nil {
+			logger.Debugw("failed to load exclude file", "filename", exclude, "error", err)
+			continue
+		}
+		if exclude == ".dockerignore" && found {
+			foundDockerIgnore = true
+		}
+		excludeFiles = append(excludeFiles, strings.Split(content, "\n")...)
+	}
+
+	// need to ensure we use a dockerignore file
+	// if we fail to load a dockerignore file, we have to exit
+	if !foundDockerIgnore {
+		dockerIgnoreContent, err := fs.ReadFile(filepath.Join("examples", string(projectType)+".dockerignore"))
+		if err != nil {
+			return fmt.Errorf("failed to load exclude file %s: %w", string(projectType), err)
+		}
+		excludeFiles = append(excludeFiles, strings.Split(string(dockerIgnoreContent), "\n")...)
+	}
+
+	matcher, err := patternmatcher.New(excludeFiles)
+	if err != nil {
+		return fmt.Errorf("failed to create pattern matcher: %w", err)
 	}
 
 	for i, exclude := range excludeFiles {
 		excludeFiles[i] = strings.TrimSpace(exclude)
 	}
 
+	checkFilesToInclude := func(path string, info os.FileInfo) bool {
+		if ignored, err := matcher.MatchesOrParentMatches(path); ignored {
+			return false
+		} else if err != nil {
+			return false
+		}
+		return true
+	}
+
+	// we walk the directory first to calculate the total size of the tarball
+	// this lets the progress bar show the correct progress
 	var totalSize int64
-	err := filepath.Walk(directory, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(directory, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -77,22 +118,8 @@ func UploadTarball(directory string, presignedUrl string, excludeFiles []string)
 			return nil
 		}
 
-		for _, exclude := range excludeFiles {
-			if exclude == "" || strings.Contains(exclude, "Dockerfile") {
-				continue
-			}
-			if info.IsDir() {
-				if strings.HasPrefix(relPath, exclude+"/") || strings.HasPrefix(relPath, exclude) {
-					return filepath.SkipDir
-				}
-			}
-			matched, err := filepath.Match(exclude, relPath)
-			if err != nil {
-				return nil
-			}
-			if matched {
-				return nil
-			}
+		if !checkFilesToInclude(relPath, info) {
+			return nil
 		}
 
 		if !info.IsDir() && info.Mode().IsRegular() {
@@ -134,26 +161,9 @@ func UploadTarball(directory string, presignedUrl string, excludeFiles []string)
 			return fmt.Errorf("failed to calculate relative path for %s: %w", path, err)
 		}
 
-		for _, exclude := range excludeFiles {
-			if exclude == "" || strings.Contains(exclude, "Dockerfile") {
-				continue
-			}
-
-			if info.IsDir() {
-				if strings.HasPrefix(relPath, exclude+"/") || strings.HasPrefix(relPath, exclude) {
-					logger.Debugw("excluding directory from tarball", "path", path)
-					return filepath.SkipDir
-				}
-			}
-
-			matched, err := filepath.Match(exclude, relPath)
-			if err != nil {
-				return nil
-			}
-			if matched {
-				logger.Debugw("excluding file from tarball", "path", path)
-				return nil
-			}
+		if !checkFilesToInclude(relPath, info) {
+			logger.Debugw("excluding file from tarball", "path", path)
+			return nil
 		}
 
 		// Follow symlinks and include the actual file contents

--- a/pkg/agentfs/tar_test.go
+++ b/pkg/agentfs/tar_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -47,7 +48,7 @@ func TestUploadTarball(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	err = UploadTarball(tmpDir, mockServer.URL, []string{})
+	err = UploadTarball(tmpDir, mockServer.URL, []string{}, ProjectTypePythonPip)
 	require.NoError(t, err)
 }
 
@@ -78,14 +79,14 @@ func TestUploadTarballFilePermissions(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	err = UploadTarball(tmpDir, mockServer.URL, []string{})
+	err = UploadTarball(tmpDir, mockServer.URL, []string{}, ProjectTypePythonPip)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "permission denied")
 
 	err = os.Remove(restrictedFile)
 	require.NoError(t, err)
 
-	err = UploadTarball(tmpDir, mockServer.URL, []string{})
+	err = UploadTarball(tmpDir, mockServer.URL, []string{}, ProjectTypePythonPip)
 	require.NoError(t, err)
 }
 
@@ -180,7 +181,7 @@ func TestUploadTarballDotfiles(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	err = UploadTarball(tmpDir, mockServer.URL, []string{})
+	err = UploadTarball(tmpDir, mockServer.URL, []string{}, ProjectTypePythonPip)
 	require.NoError(t, err)
 
 	contents := readTarContents(t, tarBuffer.Bytes())
@@ -264,7 +265,7 @@ func TestUploadTarballDeepDirectories(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	err = UploadTarball(tmpDir, mockServer.URL, []string{})
+	err = UploadTarball(tmpDir, mockServer.URL, []string{}, ProjectTypePythonPip)
 	require.NoError(t, err)
 
 	contents := readTarContents(t, tarBuffer.Bytes())
@@ -307,5 +308,398 @@ func TestUploadTarballDeepDirectories(t *testing.T) {
 			}
 		}
 		require.True(t, found, "__init__.py not found in tar: %s", initPath)
+	}
+}
+
+func TestUploadTarballWithDockerignore(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dockerignore-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	dockerignoreContent := `node_modules/
+__pycache__/
+.venv/
+venv/
+.env
+.git/
+*.log`
+
+	err = os.WriteFile(filepath.Join(tmpDir, ".dockerignore"), []byte(dockerignoreContent), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpDir, "main.py"), []byte("print('Hello World')"), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte("requests==2.28.0"), 0644)
+	require.NoError(t, err)
+
+	excludedDirs := []string{
+		"__pycache__",
+		".venv",
+		"venv",
+		".git",
+	}
+
+	for _, dir := range excludedDirs {
+		err = os.MkdirAll(filepath.Join(tmpDir, dir), 0755)
+		require.NoError(t, err)
+
+		err = os.WriteFile(filepath.Join(tmpDir, dir, "test.txt"), []byte("should be excluded"), 0644)
+		require.NoError(t, err)
+	}
+
+	err = os.WriteFile(filepath.Join(tmpDir, ".env"), []byte("SECRET_KEY=12345"), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpDir, "app.log"), []byte("log content"), 0644)
+	require.NoError(t, err)
+
+	var tarBuffer bytes.Buffer
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.Copy(&tarBuffer, r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	err = UploadTarball(tmpDir, mockServer.URL, []string{}, ProjectTypePythonPip)
+	require.NoError(t, err)
+
+	contents := readTarContents(t, tarBuffer.Bytes())
+
+	expectedFiles := map[string]bool{
+		"main.py":          false,
+		"requirements.txt": false,
+	}
+
+	for _, content := range contents {
+		if _, exists := expectedFiles[content.Name]; exists {
+			expectedFiles[content.Name] = true
+		}
+	}
+
+	for file, found := range expectedFiles {
+		require.True(t, found, "included file not found in tar: %s", file)
+	}
+
+	for _, content := range contents {
+		for _, excludedDir := range excludedDirs {
+			require.False(t, strings.HasPrefix(content.Name, excludedDir),
+				"excluded directory content found in tar: %s", content.Name)
+		}
+
+		require.NotEqual(t, ".env", content.Name, ".env file should not be in tar")
+		require.NotEqual(t, "app.log", content.Name, "*.log file should not be in tar")
+	}
+
+	for _, content := range contents {
+		require.NotEqual(t, ".dockerignore", content.Name, ".dockerignore file should not be in tar")
+	}
+}
+
+func TestUploadTarballWithPipPythonProject(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pip-python-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	err = os.WriteFile(filepath.Join(tmpDir, "main.py"), []byte("print('Hello from pip project')"), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte("requests==2.28.0\nflask==2.3.0"), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpDir, "setup.py"), []byte("from setuptools import setup\nsetup(name='myapp')"), 0644)
+	require.NoError(t, err)
+
+	excludedDirsCheck := []string{
+		"__pycache__",
+		".venv",
+		"venv",
+		".git",
+	}
+
+	for _, dir := range excludedDirsCheck {
+		err = os.MkdirAll(filepath.Join(tmpDir, dir), 0755)
+		require.NoError(t, err)
+
+		err = os.WriteFile(filepath.Join(tmpDir, dir, "test.txt"), []byte("should be excluded"), 0644)
+		require.NoError(t, err)
+	}
+
+	// create a subdir with excluded files
+	err = os.MkdirAll(filepath.Join(tmpDir, "some-dir"), 0755)
+	require.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(tmpDir, "some-dir", ".venv"), 0755)
+	require.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(tmpDir, "some-dir", "venv"), 0755)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "some-dir", ".env"), []byte("SECRET_KEY=12345"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "some-dir", "app.log"), []byte("log content"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "some-dir", "main.pyc"), []byte("compiled python"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "some-dir", "livekit.toml"), []byte("some toml content"), 0644)
+	require.NoError(t, err)
+
+	// excluded files
+	err = os.WriteFile(filepath.Join(tmpDir, ".env"), []byte("SECRET_KEY=12345"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "app.log"), []byte("log content"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "main.pyc"), []byte("compiled python"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "livekit.toml"), []byte("some toml content"), 0644)
+	require.NoError(t, err)
+
+	var tarBuffer bytes.Buffer
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.Copy(&tarBuffer, r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	err = UploadTarball(tmpDir, mockServer.URL, []string{"**/livekit.toml"}, ProjectTypePythonPip)
+	require.NoError(t, err)
+
+	contents := readTarContents(t, tarBuffer.Bytes())
+
+	expectedFiles := map[string]bool{
+		"main.py":          false,
+		"requirements.txt": false,
+		"setup.py":         false,
+	}
+
+	for _, content := range contents {
+		if _, exists := expectedFiles[content.Name]; exists {
+			expectedFiles[content.Name] = true
+		}
+	}
+
+	for file, found := range expectedFiles {
+		require.True(t, found, "included file not found in tar: %s", file)
+	}
+
+	for _, content := range contents {
+		for _, excludedDir := range excludedDirsCheck {
+			require.False(t, strings.HasPrefix(content.Name, excludedDir),
+				"excluded directory content found in tar: %s", content.Name)
+		}
+
+		excludedFiles := []string{
+			".env",
+			"app.log",
+			"main.pyc",
+			".dockerignore",
+			"some-dir/.env",
+			"some-dir/.venv",
+			"some-dir/venv",
+			"some-dir/app.log",
+			"some-dir/main.pyc",
+			"some-dir/livekit.toml",
+		}
+
+		for _, excludedFile := range excludedFiles {
+			require.NotEqual(t, excludedFile, content.Name,
+				"excluded file should not be in tar: %s", content.Name)
+		}
+	}
+
+}
+
+func TestUploadTarballWithUvPythonProject(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "uv-python-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	err = os.WriteFile(filepath.Join(tmpDir, "main.py"), []byte("print('Hello from uv project')"), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpDir, "pyproject.toml"), []byte("[project]\nname = 'myapp'\nversion = '0.1.0'"), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpDir, "utils.py"), []byte("def helper():\n    pass"), 0644)
+	require.NoError(t, err)
+
+	err = os.MkdirAll(filepath.Join(tmpDir, "some-dir"), 0755)
+	require.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(tmpDir, "some-dir", ".venv"), 0755)
+	require.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(tmpDir, "some-dir", "venv"), 0755)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "some-dir", ".env"), []byte("SECRET_KEY=12345"), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpDir, ".env"), []byte("SECRET_KEY=12345"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "app.log"), []byte("log content"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "main.pyc"), []byte("compiled python"), 0644)
+	require.NoError(t, err)
+
+	var tarBuffer bytes.Buffer
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.Copy(&tarBuffer, r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	err = UploadTarball(tmpDir, mockServer.URL, []string{"**/livekit.toml"}, ProjectTypePythonUV)
+	require.NoError(t, err)
+
+	contents := readTarContents(t, tarBuffer.Bytes())
+
+	expectedFiles := map[string]bool{
+		"main.py":        false,
+		"pyproject.toml": false,
+		"utils.py":       false,
+	}
+
+	for _, content := range contents {
+		if _, exists := expectedFiles[content.Name]; exists {
+			expectedFiles[content.Name] = true
+		}
+	}
+
+	for file, found := range expectedFiles {
+		require.True(t, found, "included file not found in tar: %s", file)
+	}
+
+	for _, content := range contents {
+		excludedDirs := []string{
+			"__pycache__",
+			".venv",
+			"venv",
+			".git",
+		}
+
+		for _, excludedDir := range excludedDirs {
+			require.False(t, strings.HasPrefix(content.Name, excludedDir),
+				"excluded directory content found in tar: %s", content.Name)
+		}
+
+		excludedFiles := []string{
+			".env",
+			"app.log",
+			"main.pyc",
+			".dockerignore",
+			"some-dir/.env",
+			"some-dir/.venv",
+			"some-dir/venv",
+			"some-dir/app.log",
+			"some-dir/main.pyc",
+			"some-dir/livekit.toml",
+		}
+
+		for _, excludedFile := range excludedFiles {
+			require.NotEqual(t, excludedFile, content.Name,
+				"excluded file should not be in tar: %s", content.Name)
+		}
+	}
+}
+
+func TestUploadTarballWithNodeProject(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "node-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	err = os.WriteFile(filepath.Join(tmpDir, "index.js"), []byte("console.log('Hello from Node project')"), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(`{"name": "myapp", "version": "1.0.0"}`), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpDir, "utils.js"), []byte("function helper() {\n    console.log('helper');\n}"), 0644)
+	require.NoError(t, err)
+
+	err = os.MkdirAll(filepath.Join(tmpDir, "some-dir"), 0755)
+	require.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(tmpDir, "some-dir", "node_modules"), 0755)
+	require.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(tmpDir, "some-dir", "dist"), 0755)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "some-dir", ".env"), []byte("NODE_ENV=development"), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpDir, ".env"), []byte("NODE_ENV=development"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "app.log"), []byte("log content"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "npm-debug.log"), []byte("npm debug"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, ".DS_Store"), []byte("mac file"), 0644)
+	require.NoError(t, err)
+
+	var tarBuffer bytes.Buffer
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.Copy(&tarBuffer, r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	err = UploadTarball(tmpDir, mockServer.URL, []string{"**/livekit.toml"}, ProjectTypeNode)
+	require.NoError(t, err)
+
+	contents := readTarContents(t, tarBuffer.Bytes())
+
+	expectedFiles := map[string]bool{
+		"index.js":     false,
+		"package.json": false,
+		"utils.js":     false,
+	}
+
+	for _, content := range contents {
+		if _, exists := expectedFiles[content.Name]; exists {
+			expectedFiles[content.Name] = true
+		}
+	}
+
+	for file, found := range expectedFiles {
+		require.True(t, found, "included file not found in tar: %s", file)
+	}
+
+	for _, content := range contents {
+		excludedDirs := []string{
+			"node_modules",
+			"dist",
+			"build",
+			"coverage",
+			".git",
+		}
+
+		for _, excludedDir := range excludedDirs {
+			require.False(t, strings.HasPrefix(content.Name, excludedDir),
+				"excluded directory content found in tar: %s", content.Name)
+		}
+
+		excludedFiles := []string{
+			".env",
+			"app.log",
+			"npm-debug.log",
+			".DS_Store",
+			".dockerignore",
+		}
+
+		for _, excludedFile := range excludedFiles {
+			require.NotEqual(t, excludedFile, content.Name,
+				"excluded file should not be in tar: %s", content.Name)
+		}
+
+		excludedPatterns := []string{
+			"node_modules",
+			"dist",
+			"build",
+			"coverage",
+			".git",
+		}
+
+		for _, pattern := range excludedPatterns {
+			if strings.Contains(content.Name, pattern) {
+				t.Errorf("excluded pattern '%s' found in tar content: %s", pattern, content.Name)
+			}
+		}
 	}
 }


### PR DESCRIPTION
- loads the existing dockerignore if there is one
- uses the project type specific dockerignore if one isn't found
- add tests to ensure both top-level and subdirs do not include ignored files

these tests pass on my local (mac), will add a workflow to run tests on PRs/merges in a following PR