### PR TITLE
fix(agents): fix failure to generate dockerfiles on windows

### DIFF
--- a/pkg/agentfs/docker.go
+++ b/pkg/agentfs/docker.go
@@ -19,6 +19,7 @@ import (
 	"embed"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -73,12 +74,16 @@ func GenerateDockerArtifacts(dir string, projectType ProjectType, settingsMap ma
 		return nil, nil, fmt.Errorf("unable to fetch client settings from server, please try again later")
 	}
 
-	dockerfileContent, err := fs.ReadFile(filepath.Join("examples", string(projectType)+".Dockerfile"))
+	// NOTE: embed.FS uses unix-style path separators on all platforms, so cannot use filepath.Join here.
+	// path.Join always uses '/' as the separator.
+	dockerfileContent, err := fs.ReadFile(path.Join("examples", string(projectType)+".Dockerfile"))
 	if err != nil {
 		return nil, nil, err
 	}
 
-	dockerIgnoreContent, err := fs.ReadFile(filepath.Join("examples", string(projectType)+".dockerignore"))
+	// NOTE: embed.FS uses unix-style path separators on all platforms, so cannot use filepath.Join here
+	// path.Join always uses '/' as the separator.
+	dockerIgnoreContent, err := fs.ReadFile(path.Join("examples", string(projectType)+".dockerignore"))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/version.go
+++ b/version.go
@@ -15,5 +15,5 @@
 package livekitcli
 
 const (
-	Version = "2.5.5"
+	Version = "2.5.6"
 )


### PR DESCRIPTION
RE: #683, we should not use `filepath.Join()` to locate embedded dockerfiles, since `embed.FS` uses unix-style path separators on all platforms. Instead, construct the path manually.

See: github.com/golang/go/issues/45230