### PR TITLE
bump major version

### DIFF
--- a/version.go
+++ b/version.go
@@ -15,5 +15,5 @@
 package livekitcli
 
 const (
-	Version = "2.5.7"
+	Version = "2.6.0"
 )


### PR DESCRIPTION
major version 2.6.0 that supports livekit-cli version header