### PR TITLE
fix build log output format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-task/task/v3 v3.44.1
 	github.com/joho/godotenv v1.5.1
 	github.com/livekit/protocol v1.42.3-0.20251024111301-1e3becbff5d1
-	github.com/livekit/server-sdk-go/v2 v2.12.4
+	github.com/livekit/server-sdk-go/v2 v2.12.7
 	github.com/moby/patternmatcher v0.6.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pion/rtcp v1.2.15

--- a/go.sum
+++ b/go.sum
@@ -271,10 +271,8 @@ github.com/livekit/protocol v1.42.3-0.20251024111301-1e3becbff5d1 h1:MBlwsnh1Zf8
 github.com/livekit/protocol v1.42.3-0.20251024111301-1e3becbff5d1/go.mod h1:ODNQZnKVH2U93PMn/NwcpPV6zOrilBpYbyncjn/rHZI=
 github.com/livekit/psrpc v0.7.0 h1:rtfqfjYN06WJYloE/S0nmkJ/Y04x4pxLQLe8kQ4FVHU=
 github.com/livekit/psrpc v0.7.0/go.mod h1:AuDC5uOoEjQJEc69v4Li3t77Ocz0e0NdjQEuFfO+vfk=
-github.com/livekit/server-sdk-go/v2 v2.12.1 h1:6F4OWwWPcUjyhaWPNL5BE1XEJt9KzX4/10P5ADeL7xY=
-github.com/livekit/server-sdk-go/v2 v2.12.1/go.mod h1:6EZr5pBYOJ4cT1i5YnZ/L+GOeOqx6e6fKtVgU8itXuc=
-github.com/livekit/server-sdk-go/v2 v2.12.4 h1:pcNCgGfO7iYb3dQij7vp2Kee8kHNRSj/lJWpA/VNtN0=
-github.com/livekit/server-sdk-go/v2 v2.12.4/go.mod h1:EGWi7fcsHawWOCxUIlnSHC3fzWBsCEscLkouIZEzGKY=
+github.com/livekit/server-sdk-go/v2 v2.12.7 h1:owHH3qRcvLVj5Fr17jbIJO5FtieuwjNhu71GwcpBhcc=
+github.com/livekit/server-sdk-go/v2 v2.12.7/go.mod h1:EGWi7fcsHawWOCxUIlnSHC3fzWBsCEscLkouIZEzGKY=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=

--- a/version.go
+++ b/version.go
@@ -15,5 +15,5 @@
 package livekitcli
 
 const (
-	Version = "2.12.3"
+	Version = "2.12.7"
 )


### PR DESCRIPTION
Bumping up version to v2.12.7 for server-sdk-go compatibility.