### PR TITLE
better error message when secrets are malformed

### DIFF
--- a/cmd/lk/agent.go
+++ b/cmd/lk/agent.go
@@ -1279,6 +1279,10 @@ func requireSecrets(_ context.Context, cmd *cli.Command, required, lazy bool) ([
 				continue
 			}
 
+			if v == "" {
+				return nil, fmt.Errorf("failed to parse secrets file: secret %s is empty, either remove it or provide a value", k)
+			}
+
 			secret := &lkproto.AgentSecret{
 				Name:  k,
 				Value: []byte(v),


### PR DESCRIPTION
if a secret file has an empty secret value, bail early. also updated server side to send better error messages

ref https://github.com/livekit/livekit-cli/issues/678