### PR TITLE
Add macOS release builds and remove Windows ARM 32-bit

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,6 +30,12 @@ builds:
     goos:
       - linux
       - windows
+      - darwin
+    ignore:
+      - goos: darwin
+        goarch: arm
+      - goos: windows
+        goarch: arm
     ldflags:
       - -s -w
 archives:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ else
 endif
 
 cli: check_lfs
-	GOOS=darwin GOARCH=arm64 go build -ldflags "-w -s" -o bin/lk ./cmd/lk
+	GOOS=darwin GOARCH=arm64 go build -ldflags "-w -s" -o bin/lk-darwin-arm64 ./cmd/lk
+	GOOS=darwin GOARCH=amd64 go build -ldflags "-w -s" -o bin/lk-darwin-amd64 ./cmd/lk
 	GOOS=linux GOARCH=amd64 go build -ldflags "-w -s" -o bin/lk-linux ./cmd/lk
 	GOOS=windows GOARCH=amd64 go build -ldflags "-w -s" -o bin/lk.exe ./cmd/lk
 
@@ -21,7 +22,11 @@ ifeq ($(DETECTED_OS),Windows)
 	cp bin/lk.exe $(GOBIN)/lk.exe
 	ln -sf $(GOBIN)/lk.exe $(GOBIN)/livekit-cli.exe
 else ifeq ($(DETECTED_OS),Darwin)
-	cp bin/lk $(GOBIN)/lk
+ifeq ($(shell uname -m),arm64)
+	cp bin/lk-darwin-arm64 $(GOBIN)/lk
+else
+	cp bin/lk-darwin-amd64 $(GOBIN)/lk
+endif
 	ln -sf $(GOBIN)/lk $(GOBIN)/livekit-cli
 else
 	cp bin/lk-linux $(GOBIN)/lk


### PR DESCRIPTION
## Summary
- Add darwin/amd64 (Intel) and darwin/arm64 (Apple Silicon) to release builds
- Remove Windows ARM 32-bit builds (non-existent architecture)
- Update Makefile to build and install appropriate macOS binaries based on architecture

## Rationale
- macOS builds were missing from releases despite Go's cross-compilation support
- Having direct binary downloads is useful for developer installs and CI/CD pipelines without requiring Homebrew
- Windows ARM 32-bit has no real-world usage (only ARM64 exists for Windows on ARM)
- Linux ARM 32-bit retained for Raspberry Pi and embedded device support

## Release Impact
New release artifacts will include:
- **macOS**: darwin/amd64, darwin/arm64
- **Linux**: linux/amd64, linux/arm64, linux/arm
- **Windows**: windows/amd64, windows/arm64