### PR TITLE
[wip] add lock file validation

### DIFF
--- a/cmd/lk/agent.go
+++ b/cmd/lk/agent.go
@@ -557,6 +557,10 @@ func createAgent(ctx context.Context, cmd *cli.Command) error {
 		}
 	}
 
+	if err := agentfs.ValidateLockFiles(os.DirFS(workingDir), projectType); err != nil {
+		return err
+	}
+
 	region := cmd.String("region")
 	if region == "" {
 		availableRegionsStr, ok := settingsMap["available_regions"]
@@ -731,6 +735,10 @@ func deployAgent(ctx context.Context, cmd *cli.Command) error {
 		} else {
 			return err
 		}
+	}
+
+	if err := agentfs.ValidateLockFiles(os.DirFS(workingDir), projectType); err != nil {
+		return err
 	}
 
 	buildContext, cancel := context.WithTimeout(ctx, buildTimeout)


### PR DESCRIPTION
if you do `lk agent create` before doing `uv sync` (or the equivalent action in other languages), it will start deploying but fail the build partway through due to missing uv.lock. The agent will also be stuck in a bad state.

This PR adds a check to make sure the relevant lock file is there before attempting to deploy.