### PR TITLE
prompt to tail logs upon `lk agent deploy`

### DIFF
--- a/cmd/lk/agent.go
+++ b/cmd/lk/agent.go
@@ -200,6 +200,7 @@ var (
 						secretsFlag,
 						secretsFileFlag,
 						secretsMountFlag,
+						silentFlag,
 						skipSDKCheckFlag,
 					},
 					// NOTE: since secrets may contain commas, or indeed any special character we might want to treat as a flag separator,
@@ -745,6 +746,38 @@ func deployAgent(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	fmt.Println("Deployed agent")
+	fmt.Println("Build completed - You can view build logs later with `lk agent logs --log-type=build`")
+
+	silent := cmd.Bool("silent")
+	if !silent {
+		var viewLogs bool = true
+		if err := huh.NewForm(
+			huh.NewGroup(
+				huh.NewConfirm().
+					Title("Agent deploying. Would you like to view logs?").
+					Description("You can view logs later with `lk agent logs`").
+					Value(&viewLogs).
+					WithTheme(util.Theme),
+			),
+		).Run(); err != nil {
+			return err
+		} else if viewLogs {
+			// Get agent info to retrieve server region
+			response, err := agentsClient.ListAgents(ctx, &lkproto.ListAgentsRequest{
+				AgentId: agentId,
+			})
+			if err != nil {
+				return fmt.Errorf("unable to get agent info for log streaming: %w", err)
+			}
+
+			if len(response.Agents) == 0 || len(response.Agents[0].AgentDeployments) == 0 {
+				return fmt.Errorf("no agent deployments found")
+			}
+
+			fmt.Println("Tailing runtime logs...safe to exit at any time")
+			return agentsClient.StreamLogs(ctx, "deploy", agentId, os.Stdout, response.Agents[0].AgentDeployments[0].ServerRegion)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
It now prompts for logs:
<img width="971" height="803" alt="image" src="https://github.com/user-attachments/assets/742e1ebd-225b-4a18-8ce1-e0b0e61d2a8b" />

and also shows the logs (from the new replica):
<img width="1460" height="227" alt="image" src="https://github.com/user-attachments/assets/69ffeaef-b8bd-4510-bcf7-e72e3f32ddf8" />
