### PR TITLE
feat: flags to log stats

### DIFF
--- a/cmd/lk/room.go
+++ b/cmd/lk/room.go
@@ -991,7 +991,7 @@ func joinRoom(ctx context.Context, cmd *cli.Command) error {
 
 	var (
 		statsGetterMu sync.Mutex
-		statsGetter   pionStats.Getter
+		statsGetters  []pionStats.Getter
 	)
 	if cmd.Bool("stats") {
 		statsFactory, err := pionStats.NewInterceptor()
@@ -1000,7 +1000,7 @@ func joinRoom(ctx context.Context, cmd *cli.Command) error {
 		}
 		statsFactory.OnNewPeerConnection(func(_ string, g pionStats.Getter) {
 			statsGetterMu.Lock()
-			statsGetter = g
+			statsGetters = append(statsGetters, g)
 			statsGetterMu.Unlock()
 		})
 		connectOpts = append(connectOpts, lksdk.WithInterceptors([]interceptor.Factory{statsFactory}))
@@ -1115,15 +1115,16 @@ func joinRoom(ctx context.Context, cmd *cli.Command) error {
 						combined[k] = v
 					}
 					statsGetterMu.Lock()
-					g := statsGetter
+					getters := make([]pionStats.Getter, len(statsGetters))
+					copy(getters, statsGetters)
 					statsGetterMu.Unlock()
-					if g != nil {
-						for _, sender := range pc.GetSenders() {
-							for _, enc := range sender.GetParameters().Encodings {
-								ssrc := uint32(enc.SSRC)
-								if ssrc == 0 {
-									continue
-								}
+					for _, sender := range pc.GetSenders() {
+						for _, enc := range sender.GetParameters().Encodings {
+							ssrc := uint32(enc.SSRC)
+							if ssrc == 0 {
+								continue
+							}
+							for _, g := range getters {
 								s := g.Get(ssrc)
 								if s == nil {
 									continue
@@ -1137,6 +1138,7 @@ func joinRoom(ctx context.Context, cmd *cli.Command) error {
 									"roundTripTime": s.RemoteInboundRTPStreamStats.RoundTripTime.Seconds(),
 									"fractionLost":  s.RemoteInboundRTPStreamStats.FractionLost,
 								}
+								break
 							}
 						}
 					}

--- a/cmd/lk/room.go
+++ b/cmd/lk/room.go
@@ -23,9 +23,12 @@ import (
 	"os/signal"
 	"regexp"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
+	"github.com/pion/interceptor"
+	pionStats "github.com/pion/interceptor/pkg/stats"
 	"github.com/pion/webrtc/v4"
 	"github.com/urfave/cli/v3"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -983,6 +986,26 @@ func joinRoom(ctx context.Context, cmd *cli.Command) error {
 		maps.Copy(participantAttributes, fileAttrs)
 	}
 
+	var connectOpts []lksdk.ConnectOption
+	connectOpts = append(connectOpts, lksdk.WithAutoSubscribe(autoSubscribe))
+
+	var (
+		statsGetterMu sync.Mutex
+		statsGetter   pionStats.Getter
+	)
+	if cmd.Bool("stats") {
+		statsFactory, err := pionStats.NewInterceptor()
+		if err != nil {
+			return err
+		}
+		statsFactory.OnNewPeerConnection(func(_ string, g pionStats.Getter) {
+			statsGetterMu.Lock()
+			statsGetter = g
+			statsGetterMu.Unlock()
+		})
+		connectOpts = append(connectOpts, lksdk.WithInterceptors([]interceptor.Factory{statsFactory}))
+	}
+
 	room, err := lksdk.ConnectToRoom(project.URL, lksdk.ConnectInfo{
 		APIKey:                project.APIKey,
 		APISecret:             project.APISecret,
@@ -990,7 +1013,7 @@ func joinRoom(ctx context.Context, cmd *cli.Command) error {
 		ParticipantIdentity:   participantIdentity,
 		ParticipantAttributes: participantAttributes,
 		ParticipantMetadata:   cmd.String("metadata"),
-	}, roomCB, lksdk.WithAutoSubscribe(autoSubscribe))
+	}, roomCB, connectOpts...)
 	if err != nil {
 		return err
 	}
@@ -1087,8 +1110,37 @@ func joinRoom(ctx context.Context, cmd *cli.Command) error {
 					if pc == nil {
 						continue
 					}
-					report := pc.GetStats()
-					logger.Infow("stats", "stats", report)
+					combined := make(map[string]interface{})
+					for k, v := range pc.GetStats() {
+						combined[k] = v
+					}
+					statsGetterMu.Lock()
+					g := statsGetter
+					statsGetterMu.Unlock()
+					if g != nil {
+						for _, sender := range pc.GetSenders() {
+							for _, enc := range sender.GetParameters().Encodings {
+								ssrc := uint32(enc.SSRC)
+								if ssrc == 0 {
+									continue
+								}
+								s := g.Get(ssrc)
+								if s == nil {
+									continue
+								}
+								id := fmt.Sprintf("RTCRemoteInboundRtp_%d", ssrc)
+								combined[id] = map[string]interface{}{
+									"type":          "remote-inbound-rtp",
+									"ssrc":          ssrc,
+									"packetsLost":   s.RemoteInboundRTPStreamStats.PacketsLost,
+									"jitter":        s.RemoteInboundRTPStreamStats.Jitter,
+									"roundTripTime": s.RemoteInboundRTPStreamStats.RoundTripTime.Seconds(),
+									"fractionLost":  s.RemoteInboundRTPStreamStats.FractionLost,
+								}
+							}
+						}
+					}
+					logger.Infow("stats", "stats", combined)
 				}
 			}
 		}()

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/livekit/server-sdk-go/v2 v2.13.3
 	github.com/moby/patternmatcher v0.6.0
 	github.com/pelletier/go-toml v1.9.5
+	github.com/pion/interceptor v0.1.43
 	github.com/pion/rtcp v1.2.16
 	github.com/pion/rtp v1.10.0
 	github.com/pion/webrtc/v4 v4.2.3
@@ -137,7 +138,6 @@ require (
 	github.com/pion/datachannel v1.6.0 // indirect
 	github.com/pion/dtls/v3 v3.0.10 // indirect
 	github.com/pion/ice/v4 v4.2.0 // indirect
-	github.com/pion/interceptor v0.1.43 // indirect
 	github.com/pion/logging v0.2.4 // indirect
 	github.com/pion/mdns/v2 v2.1.0 // indirect
 	github.com/pion/randutil v0.1.0 // indirect


### PR DESCRIPTION
We're using the client to publish videos to a room, and want to be able to get stats about the connection. This PR adds two flags to room join (`--stats` and --stats`).

```
   --stats                                    Periodically log publisher WebRTC GetStats as one JSON object per line to stderr (default: false)
   --stats-interval float                     Seconds between stats logs when --stats is set (default: 5)
```

It's helpful for our use case so wanted to offer it back to the project!