### PR TITLE
Update private-link CLI for latest protocol health-status protos

### DIFF
--- a/cmd/lk/agent_private_link.go
+++ b/cmd/lk/agent_private_link.go
@@ -19,8 +19,9 @@ var privateLinkCommands = &cli.Command{
 			Name:  "create",
 			Usage: "Create a private link",
 			Description: "Creates a private link to a customer endpoint.\n\n" +
-				"Currently expects an AWS VPC Endpoint Service Name for --endpoint.\n" +
-				"Example: com.amazonaws.vpce.us-east-1.vpce-svc-123123a1c43abc123",
+				"Supports AWS VPC Endpoint Service Names and Azure Private Link Service aliases for --endpoint.\n" +
+				"AWS example: com.amazonaws.vpce.us-east-1.vpce-svc-123123a1c43abc123\n" +
+				"Azure example: my-pls.12345678-abcd-1234-abcd-1234567890ab.eastus.azure.privatelinkservice",
 			Before: createAgentClient,
 			Action: createPrivateLink,
 			Flags: []cli.Flag{
@@ -41,7 +42,7 @@ var privateLinkCommands = &cli.Command{
 				},
 				&cli.StringFlag{
 					Name:     "endpoint",
-					Usage:    "Customer-provided endpoint identifier",
+					Usage:    "Customer-provided endpoint identifier (AWS service name or Azure PLS alias)",
 					Required: true,
 				},
 				jsonFlag,
@@ -105,14 +106,18 @@ func buildPrivateLinkListRows(links []*lkproto.PrivateLink, healthByID map[strin
 
 		status := lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_UNKNOWN.String()
 		updatedAt := "-"
+		reason := "-"
 
 		if err, ok := healthErrByID[link.PrivateLinkId]; ok && err != nil {
 			status = "ERROR"
-			updatedAt = err.Error()
+			reason = err.Error()
 		} else if health, ok := healthByID[link.PrivateLinkId]; ok && health != nil {
 			status = health.Status.String()
 			if health.UpdatedAt != nil {
 				updatedAt = health.UpdatedAt.AsTime().UTC().Format("2006-01-02T15:04:05Z07:00")
+			}
+			if health.Reason != "" {
+				reason = health.Reason
 			}
 		}
 		dns := link.Endpoint
@@ -128,6 +133,7 @@ func buildPrivateLinkListRows(links []*lkproto.PrivateLink, healthByID map[strin
 			dns,
 			status,
 			updatedAt,
+			reason,
 		})
 	}
 	return rows
@@ -218,7 +224,7 @@ func listPrivateLinks(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	rows := buildPrivateLinkListRows(resp.Items, healthByID, healthErrByID)
-	table := util.CreateTable().Headers("ID", "Name", "Region", "Port", "DNS", "Health", "Updated At").Rows(rows...)
+	table := util.CreateTable().Headers("ID", "Name", "Region", "Port", "DNS", "Health", "Updated At", "Reason").Rows(rows...)
 	fmt.Println(table)
 	return nil
 }
@@ -259,9 +265,13 @@ func getPrivateLinkHealthStatus(ctx context.Context, cmd *cli.Command) error {
 	if resp.Value.UpdatedAt != nil {
 		updatedAt = resp.Value.UpdatedAt.AsTime().UTC().Format("2006-01-02T15:04:05Z07:00")
 	}
+	reason := "-"
+	if resp.Value.Reason != "" {
+		reason = resp.Value.Reason
+	}
 	table := util.CreateTable().
-		Headers("ID", "Health", "Updated At").
-		Row(privateLinkID, resp.Value.Status.String(), updatedAt)
+		Headers("ID", "Health", "Updated At", "Reason").
+		Row(privateLinkID, resp.Value.Status.String(), updatedAt, reason)
 	fmt.Println(table)
 	return nil
 }

--- a/cmd/lk/agent_private_link.go
+++ b/cmd/lk/agent_private_link.go
@@ -19,8 +19,7 @@ var privateLinkCommands = &cli.Command{
 			Name:  "create",
 			Usage: "Create a private link",
 			Description: "Creates a private link to a customer endpoint.\n\n" +
-				"Supports AWS VPC Endpoint Service Names and Azure Private Link Service aliases for --endpoint.\n" +
-				"AWS example: com.amazonaws.vpce.us-east-1.vpce-svc-123123a1c43abc123\n" +
+				"Supports Azure Private Link Service aliases for --endpoint.\n" +
 				"Azure example: my-pls.12345678-abcd-1234-abcd-1234567890ab.eastus.azure.privatelinkservice",
 			Before: createAgentClient,
 			Action: createPrivateLink,
@@ -42,7 +41,7 @@ var privateLinkCommands = &cli.Command{
 				},
 				&cli.StringFlag{
 					Name:     "endpoint",
-					Usage:    "Customer-provided endpoint identifier (AWS service name or Azure PLS alias)",
+					Usage:    "Customer-provided endpoint identifier",
 					Required: true,
 				},
 				jsonFlag,

--- a/cmd/lk/agent_private_link_test.go
+++ b/cmd/lk/agent_private_link_test.go
@@ -74,7 +74,7 @@ func TestBuildPrivateLinkListRows_OnePrivateLink(t *testing.T) {
 	now := time.Now().UTC()
 	healthByID := map[string]*lkproto.PrivateLinkStatus{
 		"pl-1": {
-			Status:    lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_AVAILABLE,
+			Status:    lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_HEALTHY,
 			UpdatedAt: timestamppb.New(now),
 		},
 	}
@@ -86,7 +86,8 @@ func TestBuildPrivateLinkListRows_OnePrivateLink(t *testing.T) {
 	assert.Equal(t, "us-east-1", rows[0][2])
 	assert.Equal(t, "6379", rows[0][3])
 	assert.Equal(t, "orders-db-p123.link", rows[0][4])
-	assert.Equal(t, lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_AVAILABLE.String(), rows[0][5])
+	assert.Equal(t, lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_HEALTHY.String(), rows[0][5])
+	assert.Equal(t, "-", rows[0][7])
 }
 
 func TestBuildPrivateLinkListRows_TwoPrivateLinksDifferentRegions(t *testing.T) {
@@ -109,10 +110,10 @@ func TestBuildPrivateLinkListRows_TwoPrivateLinksDifferentRegions(t *testing.T) 
 
 	healthByID := map[string]*lkproto.PrivateLinkStatus{
 		"pl-1": {
-			Status: lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_AVAILABLE,
+			Status: lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_HEALTHY,
 		},
 		"pl-2": {
-			Status: lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_AVAILABLE,
+			Status: lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_HEALTHY,
 		},
 	}
 
@@ -123,6 +124,8 @@ func TestBuildPrivateLinkListRows_TwoPrivateLinksDifferentRegions(t *testing.T) 
 	assert.Equal(t, "eu-west-1", rows[1][2])
 	assert.Equal(t, "orders-db-p123.link", rows[0][4])
 	assert.Equal(t, "cache-p123.link", rows[1][4])
-	assert.Equal(t, lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_AVAILABLE.String(), rows[0][5])
-	assert.Equal(t, lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_AVAILABLE.String(), rows[1][5])
+	assert.Equal(t, lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_HEALTHY.String(), rows[0][5])
+	assert.Equal(t, lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_HEALTHY.String(), rows[1][5])
+	assert.Equal(t, "-", rows[0][7])
+	assert.Equal(t, "-", rows[1][7])
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-task/task/v3 v3.44.1
 	github.com/joho/godotenv v1.5.1
-	github.com/livekit/protocol v1.45.2-0.20260325065350-7558ba4c26d3
+	github.com/livekit/protocol v1.45.2-0.20260403195737-756a0a7cb7b9
 	github.com/livekit/server-sdk-go/v2 v2.16.1
 	github.com/mattn/go-isatty v0.0.20
 	github.com/moby/patternmatcher v0.6.0
@@ -90,7 +90,7 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
 	github.com/go-git/go-git/v5 v5.16.2 // indirect
-	github.com/go-jose/go-jose/v3 v3.0.4 // indirect
+	github.com/go-jose/go-jose/v3 v3.0.5 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/go-task/template v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMj
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
 github.com/go-git/go-git/v5 v5.16.2 h1:fT6ZIOjE5iEnkzKyxTHK1W4HGAsPhqEqiSAssSO77hM=
 github.com/go-git/go-git/v5 v5.16.2/go.mod h1:4Ge4alE/5gPs30F2H1esi2gPd69R0C39lolkucHBOp8=
-github.com/go-jose/go-jose/v3 v3.0.4 h1:Wp5HA7bLQcKnf6YYao/4kpRpVMp/yf6+pJKV8WFSaNY=
-github.com/go-jose/go-jose/v3 v3.0.4/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
+github.com/go-jose/go-jose/v3 v3.0.5 h1:BLLJWbC4nMZOfuPVxoZIxeYsn6Nl2r1fITaJ78UQlVQ=
+github.com/go-jose/go-jose/v3 v3.0.5/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -273,8 +273,8 @@ github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731 h1:9x+U2HGLrSw5AT
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20260309115634-0e2e24b36ee8 h1:coWig9fKxdb/nwOaIoGUUAogso12GblAJh/9SA9hcxk=
 github.com/livekit/mediatransportutil v0.0.0-20260309115634-0e2e24b36ee8/go.mod h1:RCd46PT+6sEztld6XpkCrG1xskb0u3SqxIjy4G897Ss=
-github.com/livekit/protocol v1.45.2-0.20260325065350-7558ba4c26d3 h1:wmg/PTPHbIXpKoQvoLcqdJS0K8KpKGf34Xe+YPOPTm8=
-github.com/livekit/protocol v1.45.2-0.20260325065350-7558ba4c26d3/go.mod h1:63AUi0vQak6Y6gPqSBHLc+ExYTUwEqF/m4b2IRW1iO0=
+github.com/livekit/protocol v1.45.2-0.20260403195737-756a0a7cb7b9 h1:dAOkOEzuSbsc0hb/m1z/2MfDo+OJA6hMqqjF8ehCD6I=
+github.com/livekit/protocol v1.45.2-0.20260403195737-756a0a7cb7b9/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/psrpc v0.7.1 h1:ms37az0QTD3UXIWuUC5D/SkmKOlRMVRsI261eBWu/Vw=
 github.com/livekit/psrpc v0.7.1/go.mod h1:bZ4iHFQptTkbPnB0LasvRNu/OBYXEu1NA6O5BMFo9kk=
 github.com/livekit/server-sdk-go/v2 v2.16.1 h1:ZkIA9OdVvQ6Up1uW/RtQ0YJUgYMJ6+ywOmDg0jX7bTg=


### PR DESCRIPTION
## Summary
- bump `github.com/livekit/protocol` to `v1.45.2-0.20260403195737-756a0a7cb7b9`
- update private-link CLI tests for renamed health status enums (`HEALTHY` etc.)
- surface the new `PrivateLinkStatus.reason` field in table output for `agent private-link list` and `agent private-link health-status`
- clarify `agent private-link create --endpoint` help text for Azure endpoint formats

## Testing
- `go test ./cmd/lk/...`