### PR TITLE
Render private-link health with human-readable labels

### DIFF
--- a/cmd/lk/agent_private_link.go
+++ b/cmd/lk/agent_private_link.go
@@ -103,15 +103,15 @@ func buildPrivateLinkListRows(links []*lkproto.PrivateLink, healthByID map[strin
 			continue
 		}
 
-		status := lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_UNKNOWN.String()
+		status := formatPrivateLinkHealthStatus(lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_UNKNOWN)
 		updatedAt := "-"
 		reason := "-"
 
 		if err, ok := healthErrByID[link.PrivateLinkId]; ok && err != nil {
-			status = "ERROR"
+			status = "Error"
 			reason = err.Error()
 		} else if health, ok := healthByID[link.PrivateLinkId]; ok && health != nil {
-			status = health.Status.String()
+			status = formatPrivateLinkHealthStatus(health.Status)
 			if health.UpdatedAt != nil {
 				updatedAt = health.UpdatedAt.AsTime().UTC().Format("2006-01-02T15:04:05Z07:00")
 			}
@@ -136,6 +136,23 @@ func buildPrivateLinkListRows(links []*lkproto.PrivateLink, healthByID map[strin
 		})
 	}
 	return rows
+}
+
+func formatPrivateLinkHealthStatus(status lkproto.PrivateLinkStatus_Status) string {
+	switch status {
+	case lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_PROVISIONING:
+		return "Provisioning"
+	case lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_PENDING_APPROVAL:
+		return "Pending Approval"
+	case lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_HEALTHY:
+		return "Healthy"
+	case lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_UNHEALTHY:
+		return "Unhealthy"
+	case lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_UNKNOWN:
+		return "Unknown"
+	default:
+		return status.String()
+	}
 }
 
 func formatPrivateLinkClientError(action string, err error) error {
@@ -270,7 +287,7 @@ func getPrivateLinkHealthStatus(ctx context.Context, cmd *cli.Command) error {
 	}
 	table := util.CreateTable().
 		Headers("ID", "Health", "Updated At", "Reason").
-		Row(privateLinkID, resp.Value.Status.String(), updatedAt, reason)
+		Row(privateLinkID, formatPrivateLinkHealthStatus(resp.Value.Status), updatedAt, reason)
 	fmt.Println(table)
 	return nil
 }

--- a/cmd/lk/agent_private_link_test.go
+++ b/cmd/lk/agent_private_link_test.go
@@ -86,7 +86,7 @@ func TestBuildPrivateLinkListRows_OnePrivateLink(t *testing.T) {
 	assert.Equal(t, "us-east-1", rows[0][2])
 	assert.Equal(t, "6379", rows[0][3])
 	assert.Equal(t, "orders-db-p123.link", rows[0][4])
-	assert.Equal(t, lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_HEALTHY.String(), rows[0][5])
+	assert.Equal(t, "Healthy", rows[0][5])
 	assert.Equal(t, "-", rows[0][7])
 }
 
@@ -124,8 +124,16 @@ func TestBuildPrivateLinkListRows_TwoPrivateLinksDifferentRegions(t *testing.T) 
 	assert.Equal(t, "eu-west-1", rows[1][2])
 	assert.Equal(t, "orders-db-p123.link", rows[0][4])
 	assert.Equal(t, "cache-p123.link", rows[1][4])
-	assert.Equal(t, lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_HEALTHY.String(), rows[0][5])
-	assert.Equal(t, lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_HEALTHY.String(), rows[1][5])
+	assert.Equal(t, "Healthy", rows[0][5])
+	assert.Equal(t, "Healthy", rows[1][5])
 	assert.Equal(t, "-", rows[0][7])
 	assert.Equal(t, "-", rows[1][7])
+}
+
+func TestFormatPrivateLinkHealthStatus(t *testing.T) {
+	assert.Equal(t, "Unknown", formatPrivateLinkHealthStatus(lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_UNKNOWN))
+	assert.Equal(t, "Provisioning", formatPrivateLinkHealthStatus(lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_PROVISIONING))
+	assert.Equal(t, "Pending Approval", formatPrivateLinkHealthStatus(lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_PENDING_APPROVAL))
+	assert.Equal(t, "Healthy", formatPrivateLinkHealthStatus(lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_HEALTHY))
+	assert.Equal(t, "Unhealthy", formatPrivateLinkHealthStatus(lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_UNHEALTHY))
 }


### PR DESCRIPTION
## Summary
- render private-link health statuses as human-readable labels in table output
- map protocol enum values to: Unknown, Provisioning, Pending Approval, Healthy, Unhealthy
- keep JSON output unchanged
- add unit test coverage for label mapping

## Testing
- `go test ./cmd/lk/...`