### PR TITLE
Support Approved private-link health status

### DIFF
--- a/cmd/lk/agent_private_link.go
+++ b/cmd/lk/agent_private_link.go
@@ -144,6 +144,8 @@ func formatPrivateLinkHealthStatus(status lkproto.PrivateLinkStatus_Status) stri
 		return "Provisioning"
 	case lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_PENDING_APPROVAL:
 		return "Pending Approval"
+	case lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_APPROVED:
+		return "Approved"
 	case lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_HEALTHY:
 		return "Healthy"
 	case lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_UNHEALTHY:

--- a/cmd/lk/agent_private_link_test.go
+++ b/cmd/lk/agent_private_link_test.go
@@ -134,6 +134,7 @@ func TestFormatPrivateLinkHealthStatus(t *testing.T) {
 	assert.Equal(t, "Unknown", formatPrivateLinkHealthStatus(lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_UNKNOWN))
 	assert.Equal(t, "Provisioning", formatPrivateLinkHealthStatus(lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_PROVISIONING))
 	assert.Equal(t, "Pending Approval", formatPrivateLinkHealthStatus(lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_PENDING_APPROVAL))
+	assert.Equal(t, "Approved", formatPrivateLinkHealthStatus(lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_APPROVED))
 	assert.Equal(t, "Healthy", formatPrivateLinkHealthStatus(lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_HEALTHY))
 	assert.Equal(t, "Unhealthy", formatPrivateLinkHealthStatus(lkproto.PrivateLinkStatus_PRIVATE_LINK_STATUS_UNHEALTHY))
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-task/task/v3 v3.44.1
 	github.com/joho/godotenv v1.5.1
-	github.com/livekit/protocol v1.45.2-0.20260403195737-756a0a7cb7b9
+	github.com/livekit/protocol v1.45.2-0.20260403232915-071d9549ba6f
 	github.com/livekit/server-sdk-go/v2 v2.16.1
 	github.com/mattn/go-isatty v0.0.20
 	github.com/moby/patternmatcher v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-task/task/v3 v3.44.1
 	github.com/joho/godotenv v1.5.1
-	github.com/livekit/protocol v1.45.2-0.20260403232915-071d9549ba6f
+	github.com/livekit/protocol v1.45.2-0.20260403233349-218b0d450bd2
 	github.com/livekit/server-sdk-go/v2 v2.16.1
 	github.com/mattn/go-isatty v0.0.20
 	github.com/moby/patternmatcher v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -277,6 +277,8 @@ github.com/livekit/protocol v1.45.2-0.20260403195737-756a0a7cb7b9 h1:dAOkOEzuSbs
 github.com/livekit/protocol v1.45.2-0.20260403195737-756a0a7cb7b9/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/protocol v1.45.2-0.20260403232915-071d9549ba6f h1:/PBq2Q1V1t2K0jxQZn4R0pKupcg0mYws/SFHXDSzq2E=
 github.com/livekit/protocol v1.45.2-0.20260403232915-071d9549ba6f/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
+github.com/livekit/protocol v1.45.2-0.20260403233349-218b0d450bd2 h1:tDAFmUQBiHpDEvfW+KzvWbqiMBgIHCveQ4IioocUzVg=
+github.com/livekit/protocol v1.45.2-0.20260403233349-218b0d450bd2/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/psrpc v0.7.1 h1:ms37az0QTD3UXIWuUC5D/SkmKOlRMVRsI261eBWu/Vw=
 github.com/livekit/psrpc v0.7.1/go.mod h1:bZ4iHFQptTkbPnB0LasvRNu/OBYXEu1NA6O5BMFo9kk=
 github.com/livekit/server-sdk-go/v2 v2.16.1 h1:ZkIA9OdVvQ6Up1uW/RtQ0YJUgYMJ6+ywOmDg0jX7bTg=

--- a/go.sum
+++ b/go.sum
@@ -275,6 +275,8 @@ github.com/livekit/mediatransportutil v0.0.0-20260309115634-0e2e24b36ee8 h1:coWi
 github.com/livekit/mediatransportutil v0.0.0-20260309115634-0e2e24b36ee8/go.mod h1:RCd46PT+6sEztld6XpkCrG1xskb0u3SqxIjy4G897Ss=
 github.com/livekit/protocol v1.45.2-0.20260403195737-756a0a7cb7b9 h1:dAOkOEzuSbsc0hb/m1z/2MfDo+OJA6hMqqjF8ehCD6I=
 github.com/livekit/protocol v1.45.2-0.20260403195737-756a0a7cb7b9/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
+github.com/livekit/protocol v1.45.2-0.20260403232915-071d9549ba6f h1:/PBq2Q1V1t2K0jxQZn4R0pKupcg0mYws/SFHXDSzq2E=
+github.com/livekit/protocol v1.45.2-0.20260403232915-071d9549ba6f/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/psrpc v0.7.1 h1:ms37az0QTD3UXIWuUC5D/SkmKOlRMVRsI261eBWu/Vw=
 github.com/livekit/psrpc v0.7.1/go.mod h1:bZ4iHFQptTkbPnB0LasvRNu/OBYXEu1NA6O5BMFo9kk=
 github.com/livekit/server-sdk-go/v2 v2.16.1 h1:ZkIA9OdVvQ6Up1uW/RtQ0YJUgYMJ6+ywOmDg0jX7bTg=


### PR DESCRIPTION
## Summary

- add CLI rendering for `PRIVATE_LINK_STATUS_APPROVED` as `Approved`
- add test coverage for approved status formatting\n- bump `github.com/livekit/protocol` to merged commit containing approved enum

## Context
- Protocol change merged in: https://github.com/livekit/protocol/pull/1480