### PR TITLE
add dispatch name to agent listing

### DIFF
--- a/cmd/lk/agent.go
+++ b/cmd/lk/agent.go
@@ -468,7 +468,6 @@ func initAgent(ctx context.Context, cmd *cli.Command) error {
 			fmt.Println("Creating sandbox app...")
 			fmt.Printf("Created sandbox app [%s]\n", util.Accented(sandboxID))
 		}
-
 	}
 
 	// Run template bootstrap
@@ -1095,6 +1094,7 @@ func listAgents(ctx context.Context, cmd *cli.Command) error {
 		}
 		rows = append(rows, []string{
 			agent.AgentId,
+			agent.AgentName,
 			strings.Join(regions, ","),
 			agent.Version,
 			agent.DeployedAt.AsTime().Format(time.RFC3339),
@@ -1102,7 +1102,7 @@ func listAgents(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	t := util.CreateTable().
-		Headers("ID", "Regions", "Version", "Deployed At").
+		Headers("ID", "Dispatch Name", "Regions", "Version", "Deployed At").
 		Rows(rows...)
 
 	fmt.Println(t)


### PR DESCRIPTION
this may show:
- '' for default dispatch agents
- '\<user-defined-dispatch-name\>'
- '\<Pending\>' for new agents (<5min) we haven't registered the name yet for
- '\<Unavailable\>' for agents who don't show the dispatch name