### PR TITLE
Show endpoint and connection_endpoint separately in private-link CLI

### DIFF
--- a/cmd/lk/agent_private_link.go
+++ b/cmd/lk/agent_private_link.go
@@ -123,7 +123,7 @@ func buildPrivateLinkListRows(links []*lkproto.PrivateLink, healthByID map[strin
 		if endpoint == "" {
 			endpoint = "-"
 		}
-		dns := link.LkEndpoint
+		dns := link.ConnectionEndpoint
 		if dns == "" {
 			dns = "-"
 		}
@@ -190,8 +190,8 @@ func createPrivateLink(ctx context.Context, cmd *cli.Command) error {
 	if resp.PrivateLink.Endpoint != "" {
 		fmt.Printf("Endpoint [%s]\n", util.Accented(resp.PrivateLink.Endpoint))
 	}
-	if resp.PrivateLink.LkEndpoint != "" {
-		fmt.Printf("Gateway DNS [%s]\n", util.Accented(resp.PrivateLink.LkEndpoint))
+	if resp.PrivateLink.ConnectionEndpoint != "" {
+		fmt.Printf("Gateway DNS [%s]\n", util.Accented(resp.PrivateLink.ConnectionEndpoint))
 	}
 	return nil
 }

--- a/cmd/lk/agent_private_link.go
+++ b/cmd/lk/agent_private_link.go
@@ -119,7 +119,11 @@ func buildPrivateLinkListRows(links []*lkproto.PrivateLink, healthByID map[strin
 				reason = health.Reason
 			}
 		}
-		dns := link.Endpoint
+		endpoint := link.Endpoint
+		if endpoint == "" {
+			endpoint = "-"
+		}
+		dns := link.LkEndpoint
 		if dns == "" {
 			dns = "-"
 		}
@@ -129,6 +133,7 @@ func buildPrivateLinkListRows(links []*lkproto.PrivateLink, healthByID map[strin
 			link.Name,
 			link.Region,
 			strconv.FormatUint(uint64(link.Port), 10),
+			endpoint,
 			dns,
 			status,
 			updatedAt,
@@ -183,7 +188,10 @@ func createPrivateLink(ctx context.Context, cmd *cli.Command) error {
 
 	fmt.Printf("Created private link [%s]\n", util.Accented(resp.PrivateLink.PrivateLinkId))
 	if resp.PrivateLink.Endpoint != "" {
-		fmt.Printf("Gateway DNS [%s]\n", util.Accented(resp.PrivateLink.Endpoint))
+		fmt.Printf("Endpoint [%s]\n", util.Accented(resp.PrivateLink.Endpoint))
+	}
+	if resp.PrivateLink.LkEndpoint != "" {
+		fmt.Printf("Gateway DNS [%s]\n", util.Accented(resp.PrivateLink.LkEndpoint))
 	}
 	return nil
 }
@@ -242,7 +250,7 @@ func listPrivateLinks(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	rows := buildPrivateLinkListRows(resp.Items, healthByID, healthErrByID)
-	table := util.CreateTable().Headers("ID", "Name", "Region", "Port", "DNS", "Health", "Updated At", "Reason").Rows(rows...)
+	table := util.CreateTable().Headers("ID", "Name", "Region", "Port", "Endpoint", "DNS", "Health", "Updated At", "Reason").Rows(rows...)
 	fmt.Println(table)
 	return nil
 }

--- a/cmd/lk/agent_private_link_test.go
+++ b/cmd/lk/agent_private_link_test.go
@@ -67,7 +67,8 @@ func TestBuildPrivateLinkListRows_OnePrivateLink(t *testing.T) {
 			Name:          "orders-db",
 			Region:        "us-east-1",
 			Port:          6379,
-			Endpoint:      "orders-db-p123.link",
+			Endpoint:      "com.amazonaws.vpce.us-east-1.vpce-svc-abc123",
+			LkEndpoint:    "orders-db-p123.link",
 		},
 	}
 
@@ -85,9 +86,10 @@ func TestBuildPrivateLinkListRows_OnePrivateLink(t *testing.T) {
 	assert.Equal(t, "orders-db", rows[0][1])
 	assert.Equal(t, "us-east-1", rows[0][2])
 	assert.Equal(t, "6379", rows[0][3])
-	assert.Equal(t, "orders-db-p123.link", rows[0][4])
-	assert.Equal(t, "Healthy", rows[0][5])
-	assert.Equal(t, "-", rows[0][7])
+	assert.Equal(t, "com.amazonaws.vpce.us-east-1.vpce-svc-abc123", rows[0][4])
+	assert.Equal(t, "orders-db-p123.link", rows[0][5])
+	assert.Equal(t, "Healthy", rows[0][6])
+	assert.Equal(t, "-", rows[0][8])
 }
 
 func TestBuildPrivateLinkListRows_TwoPrivateLinksDifferentRegions(t *testing.T) {
@@ -97,14 +99,16 @@ func TestBuildPrivateLinkListRows_TwoPrivateLinksDifferentRegions(t *testing.T) 
 			Name:          "orders-db",
 			Region:        "us-east-1",
 			Port:          6379,
-			Endpoint:      "orders-db-p123.link",
+			Endpoint:      "com.amazonaws.vpce.us-east-1.vpce-svc-abc123",
+			LkEndpoint:    "orders-db-p123.link",
 		},
 		{
 			PrivateLinkId: "pl-2",
 			Name:          "cache",
 			Region:        "eu-west-1",
 			Port:          6380,
-			Endpoint:      "cache-p123.link",
+			Endpoint:      "com.amazonaws.vpce.eu-west-1.vpce-svc-def456",
+			LkEndpoint:    "cache-p123.link",
 		},
 	}
 
@@ -122,12 +126,14 @@ func TestBuildPrivateLinkListRows_TwoPrivateLinksDifferentRegions(t *testing.T) 
 
 	assert.Equal(t, "us-east-1", rows[0][2])
 	assert.Equal(t, "eu-west-1", rows[1][2])
-	assert.Equal(t, "orders-db-p123.link", rows[0][4])
-	assert.Equal(t, "cache-p123.link", rows[1][4])
-	assert.Equal(t, "Healthy", rows[0][5])
-	assert.Equal(t, "Healthy", rows[1][5])
-	assert.Equal(t, "-", rows[0][7])
-	assert.Equal(t, "-", rows[1][7])
+	assert.Equal(t, "com.amazonaws.vpce.us-east-1.vpce-svc-abc123", rows[0][4])
+	assert.Equal(t, "com.amazonaws.vpce.eu-west-1.vpce-svc-def456", rows[1][4])
+	assert.Equal(t, "orders-db-p123.link", rows[0][5])
+	assert.Equal(t, "cache-p123.link", rows[1][5])
+	assert.Equal(t, "Healthy", rows[0][6])
+	assert.Equal(t, "Healthy", rows[1][6])
+	assert.Equal(t, "-", rows[0][8])
+	assert.Equal(t, "-", rows[1][8])
 }
 
 func TestFormatPrivateLinkHealthStatus(t *testing.T) {

--- a/cmd/lk/agent_private_link_test.go
+++ b/cmd/lk/agent_private_link_test.go
@@ -63,12 +63,12 @@ func TestBuildPrivateLinkListRows_EmptyList(t *testing.T) {
 func TestBuildPrivateLinkListRows_OnePrivateLink(t *testing.T) {
 	links := []*lkproto.PrivateLink{
 		{
-			PrivateLinkId: "pl-1",
-			Name:          "orders-db",
-			Region:        "us-east-1",
-			Port:          6379,
-			Endpoint:      "com.amazonaws.vpce.us-east-1.vpce-svc-abc123",
-			LkEndpoint:    "orders-db-p123.link",
+			PrivateLinkId:      "pl-1",
+			Name:               "orders-db",
+			Region:             "us-east-1",
+			Port:               6379,
+			Endpoint:           "com.amazonaws.vpce.us-east-1.vpce-svc-abc123",
+			ConnectionEndpoint: "orders-db-p123.link",
 		},
 	}
 
@@ -95,20 +95,20 @@ func TestBuildPrivateLinkListRows_OnePrivateLink(t *testing.T) {
 func TestBuildPrivateLinkListRows_TwoPrivateLinksDifferentRegions(t *testing.T) {
 	links := []*lkproto.PrivateLink{
 		{
-			PrivateLinkId: "pl-1",
-			Name:          "orders-db",
-			Region:        "us-east-1",
-			Port:          6379,
-			Endpoint:      "com.amazonaws.vpce.us-east-1.vpce-svc-abc123",
-			LkEndpoint:    "orders-db-p123.link",
+			PrivateLinkId:      "pl-1",
+			Name:               "orders-db",
+			Region:             "us-east-1",
+			Port:               6379,
+			Endpoint:           "com.amazonaws.vpce.us-east-1.vpce-svc-abc123",
+			ConnectionEndpoint: "orders-db-p123.link",
 		},
 		{
-			PrivateLinkId: "pl-2",
-			Name:          "cache",
-			Region:        "eu-west-1",
-			Port:          6380,
-			Endpoint:      "com.amazonaws.vpce.eu-west-1.vpce-svc-def456",
-			LkEndpoint:    "cache-p123.link",
+			PrivateLinkId:      "pl-2",
+			Name:               "cache",
+			Region:             "eu-west-1",
+			Port:               6380,
+			Endpoint:           "com.amazonaws.vpce.eu-west-1.vpce-svc-def456",
+			ConnectionEndpoint: "cache-p123.link",
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-task/task/v3 v3.44.1
 	github.com/joho/godotenv v1.5.1
-	github.com/livekit/protocol v1.45.2-0.20260407184918-09ea9ee40f6f
+	github.com/livekit/protocol v1.45.2-0.20260407211452-4513cd5b61a8
 	github.com/livekit/server-sdk-go/v2 v2.16.1
 	github.com/mattn/go-isatty v0.0.20
 	github.com/moby/patternmatcher v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-task/task/v3 v3.44.1
 	github.com/joho/godotenv v1.5.1
-	github.com/livekit/protocol v1.45.2-0.20260403233349-218b0d450bd2
+	github.com/livekit/protocol v1.45.2-0.20260407184918-09ea9ee40f6f
 	github.com/livekit/server-sdk-go/v2 v2.16.1
 	github.com/mattn/go-isatty v0.0.20
 	github.com/moby/patternmatcher v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-task/task/v3 v3.44.1
 	github.com/joho/godotenv v1.5.1
-	github.com/livekit/protocol v1.45.2-0.20260407211452-4513cd5b61a8
+	github.com/livekit/protocol v1.45.2-0.20260407211826-e6cb78a2ccd7
 	github.com/livekit/server-sdk-go/v2 v2.16.1
 	github.com/mattn/go-isatty v0.0.20
 	github.com/moby/patternmatcher v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,8 @@ github.com/livekit/protocol v1.45.2-0.20260403232915-071d9549ba6f h1:/PBq2Q1V1t2
 github.com/livekit/protocol v1.45.2-0.20260403232915-071d9549ba6f/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/protocol v1.45.2-0.20260403233349-218b0d450bd2 h1:tDAFmUQBiHpDEvfW+KzvWbqiMBgIHCveQ4IioocUzVg=
 github.com/livekit/protocol v1.45.2-0.20260403233349-218b0d450bd2/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
+github.com/livekit/protocol v1.45.2-0.20260407184918-09ea9ee40f6f h1:vHm0sjo1MrOG+MUtZ7QpwywrBaxFW4DHy0ZwcW2WYD8=
+github.com/livekit/protocol v1.45.2-0.20260407184918-09ea9ee40f6f/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/psrpc v0.7.1 h1:ms37az0QTD3UXIWuUC5D/SkmKOlRMVRsI261eBWu/Vw=
 github.com/livekit/psrpc v0.7.1/go.mod h1:bZ4iHFQptTkbPnB0LasvRNu/OBYXEu1NA6O5BMFo9kk=
 github.com/livekit/server-sdk-go/v2 v2.16.1 h1:ZkIA9OdVvQ6Up1uW/RtQ0YJUgYMJ6+ywOmDg0jX7bTg=

--- a/go.sum
+++ b/go.sum
@@ -273,14 +273,8 @@ github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731 h1:9x+U2HGLrSw5AT
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20260309115634-0e2e24b36ee8 h1:coWig9fKxdb/nwOaIoGUUAogso12GblAJh/9SA9hcxk=
 github.com/livekit/mediatransportutil v0.0.0-20260309115634-0e2e24b36ee8/go.mod h1:RCd46PT+6sEztld6XpkCrG1xskb0u3SqxIjy4G897Ss=
-github.com/livekit/protocol v1.45.2-0.20260403195737-756a0a7cb7b9 h1:dAOkOEzuSbsc0hb/m1z/2MfDo+OJA6hMqqjF8ehCD6I=
-github.com/livekit/protocol v1.45.2-0.20260403195737-756a0a7cb7b9/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
-github.com/livekit/protocol v1.45.2-0.20260403232915-071d9549ba6f h1:/PBq2Q1V1t2K0jxQZn4R0pKupcg0mYws/SFHXDSzq2E=
-github.com/livekit/protocol v1.45.2-0.20260403232915-071d9549ba6f/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
-github.com/livekit/protocol v1.45.2-0.20260403233349-218b0d450bd2 h1:tDAFmUQBiHpDEvfW+KzvWbqiMBgIHCveQ4IioocUzVg=
-github.com/livekit/protocol v1.45.2-0.20260403233349-218b0d450bd2/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
-github.com/livekit/protocol v1.45.2-0.20260407184918-09ea9ee40f6f h1:vHm0sjo1MrOG+MUtZ7QpwywrBaxFW4DHy0ZwcW2WYD8=
-github.com/livekit/protocol v1.45.2-0.20260407184918-09ea9ee40f6f/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
+github.com/livekit/protocol v1.45.2-0.20260407211452-4513cd5b61a8 h1:eqX3MP+OC+vnoJMHWdnxTIxC+nzsRq4RWoQxSGRq1oQ=
+github.com/livekit/protocol v1.45.2-0.20260407211452-4513cd5b61a8/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/psrpc v0.7.1 h1:ms37az0QTD3UXIWuUC5D/SkmKOlRMVRsI261eBWu/Vw=
 github.com/livekit/psrpc v0.7.1/go.mod h1:bZ4iHFQptTkbPnB0LasvRNu/OBYXEu1NA6O5BMFo9kk=
 github.com/livekit/server-sdk-go/v2 v2.16.1 h1:ZkIA9OdVvQ6Up1uW/RtQ0YJUgYMJ6+ywOmDg0jX7bTg=

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,8 @@ github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731 h1:9x+U2HGLrSw5AT
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20260309115634-0e2e24b36ee8 h1:coWig9fKxdb/nwOaIoGUUAogso12GblAJh/9SA9hcxk=
 github.com/livekit/mediatransportutil v0.0.0-20260309115634-0e2e24b36ee8/go.mod h1:RCd46PT+6sEztld6XpkCrG1xskb0u3SqxIjy4G897Ss=
-github.com/livekit/protocol v1.45.2-0.20260407211452-4513cd5b61a8 h1:eqX3MP+OC+vnoJMHWdnxTIxC+nzsRq4RWoQxSGRq1oQ=
-github.com/livekit/protocol v1.45.2-0.20260407211452-4513cd5b61a8/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
+github.com/livekit/protocol v1.45.2-0.20260407211826-e6cb78a2ccd7 h1:P9PSw24+aWPyYQLBqNKwuOLiFAH/Km0K916TM6gecSU=
+github.com/livekit/protocol v1.45.2-0.20260407211826-e6cb78a2ccd7/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/psrpc v0.7.1 h1:ms37az0QTD3UXIWuUC5D/SkmKOlRMVRsI261eBWu/Vw=
 github.com/livekit/psrpc v0.7.1/go.mod h1:bZ4iHFQptTkbPnB0LasvRNu/OBYXEu1NA6O5BMFo9kk=
 github.com/livekit/server-sdk-go/v2 v2.16.1 h1:ZkIA9OdVvQ6Up1uW/RtQ0YJUgYMJ6+ywOmDg0jX7bTg=


### PR DESCRIPTION
## Summary
- keep create request input unchanged (`--endpoint` => customer endpoint identifier)
- update output/display semantics:
  - `Endpoint` column/line shows customer endpoint identifier
  - `DNS` / "Gateway DNS" shows `connection_endpoint`
- update CLI tests for row layout and field mapping
- bump `github.com/livekit/protocol` to include `lk_endpoint`

## Notes
Depends on protocol change in `livekit/protocol` PR for `connection_endpoint`.

## Verification
- `go test ./cmd/lk -run 'TestBuildPrivateLinkListRows_OnePrivateLink|TestBuildPrivateLinkListRows_TwoPrivateLinksDifferentRegions|TestBuildCreatePrivateLinkRequest_HappyPath'`