### PR TITLE
Add --cloud-region support to agent private-link create

### DIFF
--- a/cmd/lk/agent_private_link.go
+++ b/cmd/lk/agent_private_link.go
@@ -19,8 +19,10 @@ var privateLinkCommands = &cli.Command{
 			Name:  "create",
 			Usage: "Create a private link",
 			Description: "Creates a private link to a customer endpoint.\n\n" +
-				"Supports Azure Private Link Service aliases for --endpoint.\n" +
-				"Azure example: my-pls.12345678-abcd-1234-abcd-1234567890ab.eastus.azure.privatelinkservice",
+				"Supports Azure Private Link Service aliases and Azure Resource IDs for --endpoint.\n" +
+				"Azure alias example: my-pls.12345678-abcd-1234-abcd-1234567890ab.eastus.azure.privatelinkservice\n" +
+				"Azure Resource ID example: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/privateLinkServices/{name}\n" +
+				"When using an Azure Resource ID, --cloud-region is required.",
 			Before: createAgentClient,
 			Action: createPrivateLink,
 			Flags: []cli.Flag{
@@ -43,6 +45,10 @@ var privateLinkCommands = &cli.Command{
 					Name:     "endpoint",
 					Usage:    "Customer-provided endpoint identifier",
 					Required: true,
+				},
+				&cli.StringFlag{
+					Name:  "cloud-region",
+					Usage: "Cloud provider region (e.g. eastus, us-east-2). Required when --endpoint is an Azure Resource ID",
 				},
 				jsonFlag,
 			},
@@ -87,12 +93,13 @@ var privateLinkCommands = &cli.Command{
 	},
 }
 
-func buildCreatePrivateLinkRequest(name, region string, port uint32, endpoint string) *lkproto.CreatePrivateLinkRequest {
+func buildCreatePrivateLinkRequest(name, region string, port uint32, endpoint, cloudRegion string) *lkproto.CreatePrivateLinkRequest {
 	return &lkproto.CreatePrivateLinkRequest{
-		Name:     name,
-		Region:   region,
-		Port:     port,
-		Endpoint: endpoint,
+		Name:        name,
+		Region:      region,
+		Port:        port,
+		Endpoint:    endpoint,
+		CloudRegion: cloudRegion,
 	}
 }
 
@@ -170,7 +177,7 @@ func formatPrivateLinkClientError(action string, err error) error {
 }
 
 func createPrivateLink(ctx context.Context, cmd *cli.Command) error {
-	req := buildCreatePrivateLinkRequest(cmd.String("name"), cmd.String("region"), uint32(cmd.Uint("port")), cmd.String("endpoint"))
+	req := buildCreatePrivateLinkRequest(cmd.String("name"), cmd.String("region"), uint32(cmd.Uint("port")), cmd.String("endpoint"), cmd.String("cloud-region"))
 	resp, err := agentsClient.CreatePrivateLink(ctx, req)
 	if err != nil {
 		return formatPrivateLinkClientError("create", err)

--- a/cmd/lk/agent_private_link.go
+++ b/cmd/lk/agent_private_link.go
@@ -39,8 +39,6 @@ var (
 		"switzerlandnorth", "switzerlandwest", "uaecentral", "uaenorth", "uksouth", "ukwest", "westcentralus",
 		"westeurope", "westindia", "westus", "westus2", "westus3",
 	}
-	awsCloudRegionSet   = toRegionSet(awsCloudRegions)
-	azureCloudRegionSet = toRegionSet(azureCloudRegions)
 )
 
 var privateLinkCommands = &cli.Command{
@@ -176,21 +174,18 @@ func validateCloudRegionForEndpoint(endpoint, cloudRegion string) error {
 	return nil
 }
 
-func toRegionSet(regions []string) map[string]struct{} {
-	regionSet := make(map[string]struct{}, len(regions))
-	for _, region := range regions {
-		regionSet[region] = struct{}{}
-	}
-	return regionSet
-}
-
 func isValidCloudRegion(cloudRegion string) bool {
-	_, validAWS := awsCloudRegionSet[cloudRegion]
-	if validAWS {
-		return true
+	for _, region := range awsCloudRegions {
+		if region == cloudRegion {
+			return true
+		}
 	}
-	_, validAzure := azureCloudRegionSet[cloudRegion]
-	return validAzure
+	for _, region := range azureCloudRegions {
+		if region == cloudRegion {
+			return true
+		}
+	}
+	return false
 }
 
 func buildPrivateLinkListRows(links []*lkproto.PrivateLink, healthByID map[string]*lkproto.PrivateLinkStatus, healthErrByID map[string]error) [][]string {

--- a/cmd/lk/agent_private_link.go
+++ b/cmd/lk/agent_private_link.go
@@ -3,42 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/livekit/livekit-cli/v2/pkg/util"
 	lkproto "github.com/livekit/protocol/livekit"
 	"github.com/twitchtv/twirp"
 	"github.com/urfave/cli/v3"
 	"google.golang.org/protobuf/proto"
-)
-
-var (
-	privateLinkAWSEndpointRegex   = regexp.MustCompile(`^com\.amazonaws\.vpce\.[a-z0-9-]+\.vpce-svc-[a-z0-9]+$`)
-	privateLinkAzureAliasRegex    = regexp.MustCompile(`\.azure\.privatelinkservice$`)
-	privateLinkAzureResourceIDReg = regexp.MustCompile(`^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft\.network/privatelinkservices/[^/]+$`)
-	// Source: https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html
-	awsCloudRegions = []string{
-		"af-south-1", "ap-east-1", "ap-east-2", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3",
-		"ap-south-1", "ap-south-2", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ap-southeast-4",
-		"ap-southeast-5", "ap-southeast-6", "ap-southeast-7", "ca-central-1", "ca-west-1", "eu-central-1",
-		"eu-central-2", "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-2", "eu-west-3",
-		"il-central-1", "me-central-1", "me-south-1", "mx-central-1", "sa-east-1", "us-east-1", "us-east-2",
-		"us-west-1", "us-west-2", "us-gov-east-1", "us-gov-west-1", "cn-north-1", "cn-northwest-1",
-	}
-	// Source: https://learn.microsoft.com/en-us/azure/reliability/regions-list
-	azureCloudRegions = []string{
-		"australiacentral", "australiacentral2", "australiaeast", "australiasoutheast", "austriaeast", "belgiumcentral",
-		"brazilsouth", "brazilsoutheast", "canadacentral", "canadaeast", "centralindia", "centralus", "chilecentral",
-		"denmarkeast", "eastasia", "eastus", "eastus2", "francecentral", "francesouth", "germanynorth",
-		"germanywestcentral", "indonesiacentral", "israelcentral", "italynorth", "japaneast", "japanwest",
-		"koreacentral", "koreasouth", "malaysiawest", "mexicocentral", "newzealandnorth", "northcentralus",
-		"northeurope", "norwayeast", "norwaywest", "polandcentral", "qatarcentral", "southafricanorth",
-		"southafricawest", "southcentralus", "southindia", "southeastasia", "spaincentral", "swedencentral",
-		"switzerlandnorth", "switzerlandwest", "uaecentral", "uaenorth", "uksouth", "ukwest", "westcentralus",
-		"westeurope", "westindia", "westus", "westus2", "westus3",
-	}
 )
 
 var privateLinkCommands = &cli.Command{
@@ -138,56 +109,6 @@ func buildCreatePrivateLinkRequest(name, region string, port uint32, endpoint, c
 	return req
 }
 
-func validateCloudRegionForEndpoint(endpoint, cloudRegion string) error {
-	normalizedEndpoint := strings.ToLower(strings.TrimSpace(endpoint))
-	normalizedCloudRegion := strings.ToLower(strings.TrimSpace(cloudRegion))
-
-	// For Azure Resource IDs, cloud-region is explicit and cannot be parsed from endpoint.
-	if privateLinkAzureResourceIDReg.MatchString(normalizedEndpoint) && normalizedCloudRegion == "" {
-		return fmt.Errorf("cloud-region is required when endpoint is an Azure Resource ID")
-	}
-
-	if normalizedCloudRegion == "" {
-		return nil
-	}
-
-	if !isValidCloudRegion(normalizedCloudRegion) {
-		return fmt.Errorf("cloud-region must be a valid AWS or Azure region (for example: us-east-2 or eastus)")
-	}
-
-	if privateLinkAWSEndpointRegex.MatchString(normalizedEndpoint) {
-		parts := strings.Split(normalizedEndpoint, ".")
-		if len(parts) >= 5 && parts[3] != "" && parts[3] != normalizedCloudRegion {
-			return fmt.Errorf("cloud-region value must match parsed region from endpoint: %s", parts[3])
-		}
-		return nil
-	}
-
-	if privateLinkAzureAliasRegex.MatchString(normalizedEndpoint) {
-		parts := strings.Split(normalizedEndpoint, ".")
-		regionIdx := len(parts) - 3
-		if regionIdx >= 0 && parts[regionIdx] != "" && parts[regionIdx] != normalizedCloudRegion {
-			return fmt.Errorf("cloud-region value must match parsed region from endpoint: %s", parts[regionIdx])
-		}
-	}
-
-	return nil
-}
-
-func isValidCloudRegion(cloudRegion string) bool {
-	for _, region := range awsCloudRegions {
-		if region == cloudRegion {
-			return true
-		}
-	}
-	for _, region := range azureCloudRegions {
-		if region == cloudRegion {
-			return true
-		}
-	}
-	return false
-}
-
 func buildPrivateLinkListRows(links []*lkproto.PrivateLink, healthByID map[string]*lkproto.PrivateLinkStatus, healthErrByID map[string]error) [][]string {
 	var rows [][]string
 	for _, link := range links {
@@ -262,10 +183,6 @@ func formatPrivateLinkClientError(action string, err error) error {
 }
 
 func createPrivateLink(ctx context.Context, cmd *cli.Command) error {
-	if err := validateCloudRegionForEndpoint(cmd.String("endpoint"), cmd.String("cloud-region")); err != nil {
-		return err
-	}
-
 	req := buildCreatePrivateLinkRequest(cmd.String("name"), cmd.String("region"), uint32(cmd.Uint("port")), cmd.String("endpoint"), cmd.String("cloud-region"))
 	resp, err := agentsClient.CreatePrivateLink(ctx, req)
 	if err != nil {

--- a/cmd/lk/agent_private_link.go
+++ b/cmd/lk/agent_private_link.go
@@ -3,13 +3,21 @@ package main
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/livekit/livekit-cli/v2/pkg/util"
 	lkproto "github.com/livekit/protocol/livekit"
 	"github.com/twitchtv/twirp"
 	"github.com/urfave/cli/v3"
 	"google.golang.org/protobuf/proto"
+)
+
+var (
+	privateLinkAWSEndpointRegex   = regexp.MustCompile(`^com\.amazonaws\.vpce\.[a-z0-9-]+\.vpce-svc-[a-z0-9]+$`)
+	privateLinkAzureAliasRegex    = regexp.MustCompile(`\.azure\.privatelinkservice$`)
+	privateLinkAzureResourceIDReg = regexp.MustCompile(`^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft\.network/privatelinkservices/[^/]+$`)
 )
 
 var privateLinkCommands = &cli.Command{
@@ -109,6 +117,37 @@ func buildCreatePrivateLinkRequest(name, region string, port uint32, endpoint, c
 	return req
 }
 
+func validateCloudRegionForEndpoint(endpoint, cloudRegion string) error {
+	normalizedEndpoint := strings.ToLower(strings.TrimSpace(endpoint))
+	normalizedCloudRegion := strings.ToLower(strings.TrimSpace(cloudRegion))
+	if normalizedCloudRegion == "" {
+		return nil
+	}
+
+	// For Azure Resource IDs, cloud-region is explicit and not parsed from endpoint.
+	if privateLinkAzureResourceIDReg.MatchString(normalizedEndpoint) {
+		return nil
+	}
+
+	if privateLinkAWSEndpointRegex.MatchString(normalizedEndpoint) {
+		parts := strings.Split(normalizedEndpoint, ".")
+		if len(parts) >= 5 && parts[3] != "" && parts[3] != normalizedCloudRegion {
+			return fmt.Errorf("cloud-region value must match parsed region from endpoint: %s", parts[3])
+		}
+		return nil
+	}
+
+	if privateLinkAzureAliasRegex.MatchString(normalizedEndpoint) {
+		parts := strings.Split(normalizedEndpoint, ".")
+		regionIdx := len(parts) - 3
+		if regionIdx >= 0 && parts[regionIdx] != "" && parts[regionIdx] != normalizedCloudRegion {
+			return fmt.Errorf("cloud-region value must match parsed region from endpoint: %s", parts[regionIdx])
+		}
+	}
+
+	return nil
+}
+
 func buildPrivateLinkListRows(links []*lkproto.PrivateLink, healthByID map[string]*lkproto.PrivateLinkStatus, healthErrByID map[string]error) [][]string {
 	var rows [][]string
 	for _, link := range links {
@@ -183,6 +222,10 @@ func formatPrivateLinkClientError(action string, err error) error {
 }
 
 func createPrivateLink(ctx context.Context, cmd *cli.Command) error {
+	if err := validateCloudRegionForEndpoint(cmd.String("endpoint"), cmd.String("cloud-region")); err != nil {
+		return err
+	}
+
 	req := buildCreatePrivateLinkRequest(cmd.String("name"), cmd.String("region"), uint32(cmd.Uint("port")), cmd.String("endpoint"), cmd.String("cloud-region"))
 	resp, err := agentsClient.CreatePrivateLink(ctx, req)
 	if err != nil {

--- a/cmd/lk/agent_private_link.go
+++ b/cmd/lk/agent_private_link.go
@@ -18,8 +18,29 @@ var (
 	privateLinkAWSEndpointRegex   = regexp.MustCompile(`^com\.amazonaws\.vpce\.[a-z0-9-]+\.vpce-svc-[a-z0-9]+$`)
 	privateLinkAzureAliasRegex    = regexp.MustCompile(`\.azure\.privatelinkservice$`)
 	privateLinkAzureResourceIDReg = regexp.MustCompile(`^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft\.network/privatelinkservices/[^/]+$`)
-	privateLinkAWSRegionRegex     = regexp.MustCompile(`^[a-z]{2}(?:-gov)?-[a-z]+-\d+$`)
-	privateLinkAzureRegionRegex   = regexp.MustCompile(`^[a-z]+[a-z0-9]*$`)
+	// Source: https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html
+	awsCloudRegions = []string{
+		"af-south-1", "ap-east-1", "ap-east-2", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3",
+		"ap-south-1", "ap-south-2", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ap-southeast-4",
+		"ap-southeast-5", "ap-southeast-6", "ap-southeast-7", "ca-central-1", "ca-west-1", "eu-central-1",
+		"eu-central-2", "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-2", "eu-west-3",
+		"il-central-1", "me-central-1", "me-south-1", "mx-central-1", "sa-east-1", "us-east-1", "us-east-2",
+		"us-west-1", "us-west-2", "us-gov-east-1", "us-gov-west-1", "cn-north-1", "cn-northwest-1",
+	}
+	// Source: https://learn.microsoft.com/en-us/azure/reliability/regions-list
+	azureCloudRegions = []string{
+		"australiacentral", "australiacentral2", "australiaeast", "australiasoutheast", "austriaeast", "belgiumcentral",
+		"brazilsouth", "brazilsoutheast", "canadacentral", "canadaeast", "centralindia", "centralus", "chilecentral",
+		"denmarkeast", "eastasia", "eastus", "eastus2", "francecentral", "francesouth", "germanynorth",
+		"germanywestcentral", "indonesiacentral", "israelcentral", "italynorth", "japaneast", "japanwest",
+		"koreacentral", "koreasouth", "malaysiawest", "mexicocentral", "newzealandnorth", "northcentralus",
+		"northeurope", "norwayeast", "norwaywest", "polandcentral", "qatarcentral", "southafricanorth",
+		"southafricawest", "southcentralus", "southindia", "southeastasia", "spaincentral", "swedencentral",
+		"switzerlandnorth", "switzerlandwest", "uaecentral", "uaenorth", "uksouth", "ukwest", "westcentralus",
+		"westeurope", "westindia", "westus", "westus2", "westus3",
+	}
+	awsCloudRegionSet   = toRegionSet(awsCloudRegions)
+	azureCloudRegionSet = toRegionSet(azureCloudRegions)
 )
 
 var privateLinkCommands = &cli.Command{
@@ -155,8 +176,21 @@ func validateCloudRegionForEndpoint(endpoint, cloudRegion string) error {
 	return nil
 }
 
+func toRegionSet(regions []string) map[string]struct{} {
+	regionSet := make(map[string]struct{}, len(regions))
+	for _, region := range regions {
+		regionSet[region] = struct{}{}
+	}
+	return regionSet
+}
+
 func isValidCloudRegion(cloudRegion string) bool {
-	return privateLinkAWSRegionRegex.MatchString(cloudRegion) || privateLinkAzureRegionRegex.MatchString(cloudRegion)
+	_, validAWS := awsCloudRegionSet[cloudRegion]
+	if validAWS {
+		return true
+	}
+	_, validAzure := azureCloudRegionSet[cloudRegion]
+	return validAzure
 }
 
 func buildPrivateLinkListRows(links []*lkproto.PrivateLink, healthByID map[string]*lkproto.PrivateLinkStatus, healthErrByID map[string]error) [][]string {

--- a/cmd/lk/agent_private_link.go
+++ b/cmd/lk/agent_private_link.go
@@ -18,6 +18,8 @@ var (
 	privateLinkAWSEndpointRegex   = regexp.MustCompile(`^com\.amazonaws\.vpce\.[a-z0-9-]+\.vpce-svc-[a-z0-9]+$`)
 	privateLinkAzureAliasRegex    = regexp.MustCompile(`\.azure\.privatelinkservice$`)
 	privateLinkAzureResourceIDReg = regexp.MustCompile(`^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft\.network/privatelinkservices/[^/]+$`)
+	privateLinkAWSRegionRegex     = regexp.MustCompile(`^[a-z]{2}(?:-gov)?-[a-z]+-\d+$`)
+	privateLinkAzureRegionRegex   = regexp.MustCompile(`^[a-z]+[a-z0-9]*$`)
 )
 
 var privateLinkCommands = &cli.Command{
@@ -120,13 +122,18 @@ func buildCreatePrivateLinkRequest(name, region string, port uint32, endpoint, c
 func validateCloudRegionForEndpoint(endpoint, cloudRegion string) error {
 	normalizedEndpoint := strings.ToLower(strings.TrimSpace(endpoint))
 	normalizedCloudRegion := strings.ToLower(strings.TrimSpace(cloudRegion))
+
+	// For Azure Resource IDs, cloud-region is explicit and cannot be parsed from endpoint.
+	if privateLinkAzureResourceIDReg.MatchString(normalizedEndpoint) && normalizedCloudRegion == "" {
+		return fmt.Errorf("cloud-region is required when endpoint is an Azure Resource ID")
+	}
+
 	if normalizedCloudRegion == "" {
 		return nil
 	}
 
-	// For Azure Resource IDs, cloud-region is explicit and not parsed from endpoint.
-	if privateLinkAzureResourceIDReg.MatchString(normalizedEndpoint) {
-		return nil
+	if !isValidCloudRegion(normalizedCloudRegion) {
+		return fmt.Errorf("cloud-region must be a valid AWS or Azure region (for example: us-east-2 or eastus)")
 	}
 
 	if privateLinkAWSEndpointRegex.MatchString(normalizedEndpoint) {
@@ -146,6 +153,10 @@ func validateCloudRegionForEndpoint(endpoint, cloudRegion string) error {
 	}
 
 	return nil
+}
+
+func isValidCloudRegion(cloudRegion string) bool {
+	return privateLinkAWSRegionRegex.MatchString(cloudRegion) || privateLinkAzureRegionRegex.MatchString(cloudRegion)
 }
 
 func buildPrivateLinkListRows(links []*lkproto.PrivateLink, healthByID map[string]*lkproto.PrivateLinkStatus, healthErrByID map[string]error) [][]string {

--- a/cmd/lk/agent_private_link.go
+++ b/cmd/lk/agent_private_link.go
@@ -9,6 +9,7 @@ import (
 	lkproto "github.com/livekit/protocol/livekit"
 	"github.com/twitchtv/twirp"
 	"github.com/urfave/cli/v3"
+	"google.golang.org/protobuf/proto"
 )
 
 var privateLinkCommands = &cli.Command{
@@ -94,13 +95,18 @@ var privateLinkCommands = &cli.Command{
 }
 
 func buildCreatePrivateLinkRequest(name, region string, port uint32, endpoint, cloudRegion string) *lkproto.CreatePrivateLinkRequest {
-	return &lkproto.CreatePrivateLinkRequest{
-		Name:        name,
-		Region:      region,
-		Port:        port,
-		Endpoint:    endpoint,
-		CloudRegion: cloudRegion,
+	req := &lkproto.CreatePrivateLinkRequest{
+		Name:     name,
+		Region:   region,
+		Port:     port,
+		Endpoint: endpoint,
 	}
+
+	if cloudRegion != "" {
+		req.CloudRegion = proto.String(cloudRegion)
+	}
+
+	return req
 }
 
 func buildPrivateLinkListRows(links []*lkproto.PrivateLink, healthByID map[string]*lkproto.PrivateLinkStatus, healthErrByID map[string]error) [][]string {

--- a/cmd/lk/agent_private_link_test.go
+++ b/cmd/lk/agent_private_link_test.go
@@ -63,40 +63,6 @@ func TestBuildCreatePrivateLinkRequest_OmitsOptionalCloudRegionWhenEmpty(t *test
 	assert.Nil(t, req.CloudRegion)
 }
 
-func TestValidateCloudRegionForEndpoint_FailsOnMismatchedAzureAlias(t *testing.T) {
-	err := validateCloudRegionForEndpoint("my-pls.12345678-abcd-1234-abcd-1234567890ab.eastus.azure.privatelinkservice", "westus")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "cloud-region value must match parsed region from endpoint: eastus")
-}
-
-func TestValidateCloudRegionForEndpoint_AllowsAzureResourceID(t *testing.T) {
-	err := validateCloudRegionForEndpoint("/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Network/privateLinkServices/my-pls", "westus")
-	require.NoError(t, err)
-}
-
-func TestValidateCloudRegionForEndpoint_AllowsKnownAWSRegion(t *testing.T) {
-	err := validateCloudRegionForEndpoint("/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Network/privateLinkServices/my-pls", "us-east-2")
-	require.NoError(t, err)
-}
-
-func TestValidateCloudRegionForEndpoint_RequiresCloudRegionForAzureResourceID(t *testing.T) {
-	err := validateCloudRegionForEndpoint("/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Network/privateLinkServices/my-pls", "")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "cloud-region is required when endpoint is an Azure Resource ID")
-}
-
-func TestValidateCloudRegionForEndpoint_RejectsInvalidCloudRegion(t *testing.T) {
-	err := validateCloudRegionForEndpoint("/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Network/privateLinkServices/my-pls", "east us")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "cloud-region must be a valid AWS or Azure region")
-}
-
-func TestValidateCloudRegionForEndpoint_RejectsUnknownRegionCode(t *testing.T) {
-	err := validateCloudRegionForEndpoint("/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Network/privateLinkServices/my-pls", "us-mars-1")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "cloud-region must be a valid AWS or Azure region")
-}
-
 func TestBuildPrivateLinkListRows_EmptyList(t *testing.T) {
 	rows := buildPrivateLinkListRows([]*lkproto.PrivateLink{}, map[string]*lkproto.PrivateLinkStatus{}, map[string]error{})
 	assert.Empty(t, rows)

--- a/cmd/lk/agent_private_link_test.go
+++ b/cmd/lk/agent_private_link_test.go
@@ -74,6 +74,11 @@ func TestValidateCloudRegionForEndpoint_AllowsAzureResourceID(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestValidateCloudRegionForEndpoint_AllowsKnownAWSRegion(t *testing.T) {
+	err := validateCloudRegionForEndpoint("/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Network/privateLinkServices/my-pls", "us-east-2")
+	require.NoError(t, err)
+}
+
 func TestValidateCloudRegionForEndpoint_RequiresCloudRegionForAzureResourceID(t *testing.T) {
 	err := validateCloudRegionForEndpoint("/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Network/privateLinkServices/my-pls", "")
 	require.Error(t, err)
@@ -86,9 +91,10 @@ func TestValidateCloudRegionForEndpoint_RejectsInvalidCloudRegion(t *testing.T) 
 	require.Contains(t, err.Error(), "cloud-region must be a valid AWS or Azure region")
 }
 
-func TestValidateCloudRegionForEndpoint_AllowsValidAWSRegionWithAzureResourceID(t *testing.T) {
-	err := validateCloudRegionForEndpoint("/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Network/privateLinkServices/my-pls", "us-east-2")
-	require.NoError(t, err)
+func TestValidateCloudRegionForEndpoint_RejectsUnknownRegionCode(t *testing.T) {
+	err := validateCloudRegionForEndpoint("/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Network/privateLinkServices/my-pls", "us-mars-1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cloud-region must be a valid AWS or Azure region")
 }
 
 func TestBuildPrivateLinkListRows_EmptyList(t *testing.T) {

--- a/cmd/lk/agent_private_link_test.go
+++ b/cmd/lk/agent_private_link_test.go
@@ -45,7 +45,7 @@ func TestAgentPrivateLinkCommandTree(t *testing.T) {
 }
 
 func TestBuildCreatePrivateLinkRequest_HappyPath(t *testing.T) {
-	req := buildCreatePrivateLinkRequest("orders-db", "us-east-1", 6379, "com.amazonaws.vpce.us-east-1.vpce-svc-abc123")
+	req := buildCreatePrivateLinkRequest("orders-db", "us-east-1", 6379, "com.amazonaws.vpce.us-east-1.vpce-svc-abc123", "us-east-1")
 	require.NotNil(t, req)
 
 	assert.Equal(t, "orders-db", req.Name)
@@ -53,6 +53,7 @@ func TestBuildCreatePrivateLinkRequest_HappyPath(t *testing.T) {
 	assert.Equal(t, uint32(6379), req.Port)
 
 	assert.Equal(t, "com.amazonaws.vpce.us-east-1.vpce-svc-abc123", req.Endpoint)
+	assert.Equal(t, "us-east-1", req.CloudRegion)
 }
 
 func TestBuildPrivateLinkListRows_EmptyList(t *testing.T) {

--- a/cmd/lk/agent_private_link_test.go
+++ b/cmd/lk/agent_private_link_test.go
@@ -74,6 +74,23 @@ func TestValidateCloudRegionForEndpoint_AllowsAzureResourceID(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestValidateCloudRegionForEndpoint_RequiresCloudRegionForAzureResourceID(t *testing.T) {
+	err := validateCloudRegionForEndpoint("/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Network/privateLinkServices/my-pls", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cloud-region is required when endpoint is an Azure Resource ID")
+}
+
+func TestValidateCloudRegionForEndpoint_RejectsInvalidCloudRegion(t *testing.T) {
+	err := validateCloudRegionForEndpoint("/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Network/privateLinkServices/my-pls", "east us")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cloud-region must be a valid AWS or Azure region")
+}
+
+func TestValidateCloudRegionForEndpoint_AllowsValidAWSRegionWithAzureResourceID(t *testing.T) {
+	err := validateCloudRegionForEndpoint("/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Network/privateLinkServices/my-pls", "us-east-2")
+	require.NoError(t, err)
+}
+
 func TestBuildPrivateLinkListRows_EmptyList(t *testing.T) {
 	rows := buildPrivateLinkListRows([]*lkproto.PrivateLink{}, map[string]*lkproto.PrivateLinkStatus{}, map[string]error{})
 	assert.Empty(t, rows)

--- a/cmd/lk/agent_private_link_test.go
+++ b/cmd/lk/agent_private_link_test.go
@@ -63,6 +63,17 @@ func TestBuildCreatePrivateLinkRequest_OmitsOptionalCloudRegionWhenEmpty(t *test
 	assert.Nil(t, req.CloudRegion)
 }
 
+func TestValidateCloudRegionForEndpoint_FailsOnMismatchedAzureAlias(t *testing.T) {
+	err := validateCloudRegionForEndpoint("my-pls.12345678-abcd-1234-abcd-1234567890ab.eastus.azure.privatelinkservice", "westus")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cloud-region value must match parsed region from endpoint: eastus")
+}
+
+func TestValidateCloudRegionForEndpoint_AllowsAzureResourceID(t *testing.T) {
+	err := validateCloudRegionForEndpoint("/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Network/privateLinkServices/my-pls", "westus")
+	require.NoError(t, err)
+}
+
 func TestBuildPrivateLinkListRows_EmptyList(t *testing.T) {
 	rows := buildPrivateLinkListRows([]*lkproto.PrivateLink{}, map[string]*lkproto.PrivateLinkStatus{}, map[string]error{})
 	assert.Empty(t, rows)

--- a/cmd/lk/agent_private_link_test.go
+++ b/cmd/lk/agent_private_link_test.go
@@ -53,7 +53,14 @@ func TestBuildCreatePrivateLinkRequest_HappyPath(t *testing.T) {
 	assert.Equal(t, uint32(6379), req.Port)
 
 	assert.Equal(t, "com.amazonaws.vpce.us-east-1.vpce-svc-abc123", req.Endpoint)
-	assert.Equal(t, "us-east-1", req.CloudRegion)
+	require.NotNil(t, req.CloudRegion)
+	assert.Equal(t, "us-east-1", *req.CloudRegion)
+}
+
+func TestBuildCreatePrivateLinkRequest_OmitsOptionalCloudRegionWhenEmpty(t *testing.T) {
+	req := buildCreatePrivateLinkRequest("orders-db", "us-east-1", 6379, "com.amazonaws.vpce.us-east-1.vpce-svc-abc123", "")
+	require.NotNil(t, req)
+	assert.Nil(t, req.CloudRegion)
 }
 
 func TestBuildPrivateLinkListRows_EmptyList(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-task/task/v3 v3.49.1
 	github.com/google/go-querystring v1.2.0
 	github.com/joho/godotenv v1.5.1
-	github.com/livekit/protocol v1.45.2-0.20260407211826-e6cb78a2ccd7
+	github.com/livekit/protocol v1.45.4-0.20260414173916-43b3b89de448
 	github.com/livekit/server-sdk-go/v2 v2.16.1
 	github.com/mattn/go-isatty v0.0.21
 	github.com/moby/patternmatcher v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-task/task/v3 v3.49.1
 	github.com/google/go-querystring v1.2.0
 	github.com/joho/godotenv v1.5.1
-	github.com/livekit/protocol v1.45.4-0.20260414173916-43b3b89de448
+	github.com/livekit/protocol v1.45.4-0.20260414175133-fe91f1e1ce43
 	github.com/livekit/server-sdk-go/v2 v2.16.1
 	github.com/mattn/go-isatty v0.0.21
 	github.com/moby/patternmatcher v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-task/task/v3 v3.49.1
 	github.com/google/go-querystring v1.2.0
 	github.com/joho/godotenv v1.5.1
-	github.com/livekit/protocol v1.45.4-0.20260414175133-fe91f1e1ce43
+	github.com/livekit/protocol v1.45.4-0.20260414175434-28604d1045cd
 	github.com/livekit/server-sdk-go/v2 v2.16.1
 	github.com/mattn/go-isatty v0.0.21
 	github.com/moby/patternmatcher v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -407,6 +407,8 @@ github.com/livekit/mediatransportutil v0.0.0-20260309115634-0e2e24b36ee8 h1:coWi
 github.com/livekit/mediatransportutil v0.0.0-20260309115634-0e2e24b36ee8/go.mod h1:RCd46PT+6sEztld6XpkCrG1xskb0u3SqxIjy4G897Ss=
 github.com/livekit/protocol v1.45.2-0.20260407211826-e6cb78a2ccd7 h1:P9PSw24+aWPyYQLBqNKwuOLiFAH/Km0K916TM6gecSU=
 github.com/livekit/protocol v1.45.2-0.20260407211826-e6cb78a2ccd7/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
+github.com/livekit/protocol v1.45.4-0.20260414173916-43b3b89de448 h1:vj8TswaAHqAWYYWI2bL1nbH2AoCh6qse7SixYvS3/d0=
+github.com/livekit/protocol v1.45.4-0.20260414173916-43b3b89de448/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/psrpc v0.7.1 h1:ms37az0QTD3UXIWuUC5D/SkmKOlRMVRsI261eBWu/Vw=
 github.com/livekit/psrpc v0.7.1/go.mod h1:bZ4iHFQptTkbPnB0LasvRNu/OBYXEu1NA6O5BMFo9kk=
 github.com/livekit/server-sdk-go/v2 v2.16.1 h1:ZkIA9OdVvQ6Up1uW/RtQ0YJUgYMJ6+ywOmDg0jX7bTg=

--- a/go.sum
+++ b/go.sum
@@ -411,6 +411,8 @@ github.com/livekit/protocol v1.45.4-0.20260414173916-43b3b89de448 h1:vj8TswaAHqA
 github.com/livekit/protocol v1.45.4-0.20260414173916-43b3b89de448/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/protocol v1.45.4-0.20260414175133-fe91f1e1ce43 h1:b1ANb09PijSDuZR2UDjzAeKxrKnswb0814IOFO+5zP4=
 github.com/livekit/protocol v1.45.4-0.20260414175133-fe91f1e1ce43/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
+github.com/livekit/protocol v1.45.4-0.20260414175434-28604d1045cd h1:T6z+yCaQGs8C+fSWXo8ZfM2qUyEpoC6Fbaa/dR3JodU=
+github.com/livekit/protocol v1.45.4-0.20260414175434-28604d1045cd/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/psrpc v0.7.1 h1:ms37az0QTD3UXIWuUC5D/SkmKOlRMVRsI261eBWu/Vw=
 github.com/livekit/psrpc v0.7.1/go.mod h1:bZ4iHFQptTkbPnB0LasvRNu/OBYXEu1NA6O5BMFo9kk=
 github.com/livekit/server-sdk-go/v2 v2.16.1 h1:ZkIA9OdVvQ6Up1uW/RtQ0YJUgYMJ6+ywOmDg0jX7bTg=

--- a/go.sum
+++ b/go.sum
@@ -409,6 +409,8 @@ github.com/livekit/protocol v1.45.2-0.20260407211826-e6cb78a2ccd7 h1:P9PSw24+aWP
 github.com/livekit/protocol v1.45.2-0.20260407211826-e6cb78a2ccd7/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/protocol v1.45.4-0.20260414173916-43b3b89de448 h1:vj8TswaAHqAWYYWI2bL1nbH2AoCh6qse7SixYvS3/d0=
 github.com/livekit/protocol v1.45.4-0.20260414173916-43b3b89de448/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
+github.com/livekit/protocol v1.45.4-0.20260414175133-fe91f1e1ce43 h1:b1ANb09PijSDuZR2UDjzAeKxrKnswb0814IOFO+5zP4=
+github.com/livekit/protocol v1.45.4-0.20260414175133-fe91f1e1ce43/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/psrpc v0.7.1 h1:ms37az0QTD3UXIWuUC5D/SkmKOlRMVRsI261eBWu/Vw=
 github.com/livekit/psrpc v0.7.1/go.mod h1:bZ4iHFQptTkbPnB0LasvRNu/OBYXEu1NA6O5BMFo9kk=
 github.com/livekit/server-sdk-go/v2 v2.16.1 h1:ZkIA9OdVvQ6Up1uW/RtQ0YJUgYMJ6+ywOmDg0jX7bTg=


### PR DESCRIPTION
## Summary
- add optional `--cloud-region` flag to `lk agent private-link create`
- update command description to include Azure alias + Azure Resource ID endpoint formats
- pass `cloud_region` through `CreatePrivateLinkRequest`
- bump `github.com/livekit/protocol` to include `cloud_region` field

## Validation
- `go test ./cmd/lk -run TestBuildCreatePrivateLinkRequest_HappyPath -count=1`

## Depends On
- https://github.com/livekit/protocol/pull/1498
