### PR TITLE
Show region picker for private-link create when --region is unset

### DIFF
--- a/cmd/lk/agent.go
+++ b/cmd/lk/agent.go
@@ -577,33 +577,9 @@ func createAgent(ctx context.Context, cmd *cli.Command) error {
 		}
 	}
 
-	region := cmd.String("region")
-	if region == "" {
-		availableRegionsStr, ok := settingsMap["available_regions"]
-		if ok && availableRegionsStr != "" {
-			regionOptions := strings.Split(availableRegionsStr, ",")
-			for i, r := range regionOptions {
-				regionOptions[i] = strings.TrimSpace(r)
-			}
-			slices.Sort(regionOptions)
-			slices.Reverse(regionOptions)
-
-			if SkipPrompts(cmd) {
-				return fmt.Errorf("non-interactive mode: --region flag must be specified, available regions: %v", regionOptions)
-			} else if err := huh.NewSelect[string]().
-				Title("Select region for agent deployment").
-				Options(huh.NewOptions(regionOptions...)...).
-				Value(&region).
-				WithTheme(util.Theme).
-				Run(); err != nil {
-				return err
-			}
-			fmt.Fprintf(os.Stderr, "Using region [%s]\n", util.Accented(region))
-		} else {
-			// we shouldn't ever get here, but if we do, just default to us-east
-			logger.Debugw("no available regions found, defaulting to us-east. please contact LiveKit support if this is unexpected.")
-			region = "us-east"
-		}
+	region, err := resolveRegion(cmd, settingsMap, "Select region for agent deployment")
+	if err != nil {
+		return err
 	}
 
 	buildContext, cancel := context.WithTimeout(ctx, buildTimeout)
@@ -1465,6 +1441,46 @@ func getClientSettings(ctx context.Context, silent bool) (map[string]string, err
 	}
 
 	return settingsMap, nil
+}
+
+// resolveRegion returns the LiveKit region to use, prompting the user with a
+// picker populated from server-reported available_regions when --region is
+// unset and the CLI is interactive. In non-interactive mode an unset --region
+// is an error so invocations fail loudly instead of silently defaulting.
+func resolveRegion(cmd *cli.Command, settingsMap map[string]string, title string) (string, error) {
+	if region := cmd.String("region"); region != "" {
+		return region, nil
+	}
+
+	availableRegionsStr, ok := settingsMap["available_regions"]
+	if !ok || availableRegionsStr == "" {
+		// we shouldn't ever get here, but if we do, just default to us-east
+		logger.Debugw("no available regions found, defaulting to us-east. please contact LiveKit support if this is unexpected.")
+		return "us-east", nil
+	}
+
+	regionOptions := strings.Split(availableRegionsStr, ",")
+	for i, r := range regionOptions {
+		regionOptions[i] = strings.TrimSpace(r)
+	}
+	slices.Sort(regionOptions)
+	slices.Reverse(regionOptions)
+
+	if SkipPrompts(cmd) {
+		return "", fmt.Errorf("non-interactive mode: --region flag must be specified, available regions: %v", regionOptions)
+	}
+
+	var region string
+	if err := huh.NewSelect[string]().
+		Title(title).
+		Options(huh.NewOptions(regionOptions...)...).
+		Value(&region).
+		WithTheme(util.Theme).
+		Run(); err != nil {
+		return "", err
+	}
+	fmt.Fprintf(os.Stderr, "Using region [%s]\n", util.Accented(region))
+	return region, nil
 }
 
 func requireConfig(workingDir, tomlFilename string) (bool, error) {

--- a/cmd/lk/agent_private_link.go
+++ b/cmd/lk/agent_private_link.go
@@ -33,9 +33,8 @@ var privateLinkCommands = &cli.Command{
 					Required: true,
 				},
 				&cli.StringFlag{
-					Name:     "region",
-					Usage:    "LiveKit region",
-					Required: true,
+					Name:  "region",
+					Usage: "LiveKit region. If unset in interactive mode, a picker of available regions is shown.",
 				},
 				&cli.UintFlag{
 					Name:     "port",
@@ -183,7 +182,17 @@ func formatPrivateLinkClientError(action string, err error) error {
 }
 
 func createPrivateLink(ctx context.Context, cmd *cli.Command) error {
-	req := buildCreatePrivateLinkRequest(cmd.String("name"), cmd.String("region"), uint32(cmd.Uint("port")), cmd.String("endpoint"), cmd.String("cloud-region"))
+	settingsMap, err := getClientSettings(ctx, false)
+	if err != nil {
+		return err
+	}
+
+	region, err := resolveRegion(cmd, settingsMap, "Select region for private link")
+	if err != nil {
+		return err
+	}
+
+	req := buildCreatePrivateLinkRequest(cmd.String("name"), region, uint32(cmd.Uint("port")), cmd.String("endpoint"), cmd.String("cloud-region"))
 	resp, err := agentsClient.CreatePrivateLink(ctx, req)
 	if err != nil {
 		return formatPrivateLinkClientError("create", err)


### PR DESCRIPTION
## Summary
- Factors the region-resolution UX out of `agent create` into a shared `resolveRegion` helper in `cmd/lk/agent.go`.
- Reuses the helper in `private-link create` so that command now presents the same interactive picker of available regions (pulled from `available_regions` client settings) when `--region` isn't passed.
- Relaxes `--region` on `private-link create` from `Required: true` to optional so the picker can kick in; non-interactive invocations still fail loudly with the list of available regions instead of silently defaulting.

### What it looks like 

```
lk) drshrey@Shreyass-MBP livekit-cli % ./bin/lk agent private-link create --name test-pl --port 6379 --endpoint foobar
Using default project [private-cloud-agents-project3]
┃ Select region for private link                                                            
┃   us-west                                                                                 
┃   us-central                                                                              
┃ > ca-central 
```