### PR TITLE
Display cloud_region for private links

### DIFF
--- a/cmd/lk/agent_private_link.go
+++ b/cmd/lk/agent_private_link.go
@@ -139,11 +139,16 @@ func buildPrivateLinkListRows(links []*lkproto.PrivateLink, healthByID map[strin
 		if dns == "" {
 			dns = "-"
 		}
+		cloudRegion := link.CloudRegion
+		if cloudRegion == "" {
+			cloudRegion = "-"
+		}
 
 		rows = append(rows, []string{
 			link.PrivateLinkId,
 			link.Name,
 			link.Region,
+			cloudRegion,
 			strconv.FormatUint(uint64(link.Port), 10),
 			endpoint,
 			dns,
@@ -215,6 +220,9 @@ func createPrivateLink(ctx context.Context, cmd *cli.Command) error {
 	if resp.PrivateLink.ConnectionEndpoint != "" {
 		fmt.Printf("Gateway DNS [%s]\n", util.Accented(resp.PrivateLink.ConnectionEndpoint))
 	}
+	if resp.PrivateLink.CloudRegion != "" {
+		fmt.Printf("Cloud Region [%s]\n", util.Accented(resp.PrivateLink.CloudRegion))
+	}
 	return nil
 }
 
@@ -272,7 +280,7 @@ func listPrivateLinks(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	rows := buildPrivateLinkListRows(resp.Items, healthByID, healthErrByID)
-	table := util.CreateTable().Headers("ID", "Name", "Region", "Port", "Endpoint", "DNS", "Health", "Updated At", "Reason").Rows(rows...)
+	table := util.CreateTable().Headers("ID", "Name", "Region", "Cloud Region", "Port", "Endpoint", "DNS", "Health", "Updated At", "Reason").Rows(rows...)
 	fmt.Println(table)
 	return nil
 }

--- a/cmd/lk/agent_private_link_test.go
+++ b/cmd/lk/agent_private_link_test.go
@@ -74,6 +74,7 @@ func TestBuildPrivateLinkListRows_OnePrivateLink(t *testing.T) {
 			PrivateLinkId:      "pl-1",
 			Name:               "orders-db",
 			Region:             "us-east-1",
+			CloudRegion:        "us-east-1",
 			Port:               6379,
 			Endpoint:           "com.amazonaws.vpce.us-east-1.vpce-svc-abc123",
 			ConnectionEndpoint: "orders-db-p123.link",
@@ -93,11 +94,12 @@ func TestBuildPrivateLinkListRows_OnePrivateLink(t *testing.T) {
 	assert.Equal(t, "pl-1", rows[0][0])
 	assert.Equal(t, "orders-db", rows[0][1])
 	assert.Equal(t, "us-east-1", rows[0][2])
-	assert.Equal(t, "6379", rows[0][3])
-	assert.Equal(t, "com.amazonaws.vpce.us-east-1.vpce-svc-abc123", rows[0][4])
-	assert.Equal(t, "orders-db-p123.link", rows[0][5])
-	assert.Equal(t, "Healthy", rows[0][6])
-	assert.Equal(t, "-", rows[0][8])
+	assert.Equal(t, "us-east-1", rows[0][3])
+	assert.Equal(t, "6379", rows[0][4])
+	assert.Equal(t, "com.amazonaws.vpce.us-east-1.vpce-svc-abc123", rows[0][5])
+	assert.Equal(t, "orders-db-p123.link", rows[0][6])
+	assert.Equal(t, "Healthy", rows[0][7])
+	assert.Equal(t, "-", rows[0][9])
 }
 
 func TestBuildPrivateLinkListRows_TwoPrivateLinksDifferentRegions(t *testing.T) {
@@ -106,6 +108,7 @@ func TestBuildPrivateLinkListRows_TwoPrivateLinksDifferentRegions(t *testing.T) 
 			PrivateLinkId:      "pl-1",
 			Name:               "orders-db",
 			Region:             "us-east-1",
+			CloudRegion:        "us-east-1",
 			Port:               6379,
 			Endpoint:           "com.amazonaws.vpce.us-east-1.vpce-svc-abc123",
 			ConnectionEndpoint: "orders-db-p123.link",
@@ -114,6 +117,7 @@ func TestBuildPrivateLinkListRows_TwoPrivateLinksDifferentRegions(t *testing.T) 
 			PrivateLinkId:      "pl-2",
 			Name:               "cache",
 			Region:             "eu-west-1",
+			CloudRegion:        "eu-west-1",
 			Port:               6380,
 			Endpoint:           "com.amazonaws.vpce.eu-west-1.vpce-svc-def456",
 			ConnectionEndpoint: "cache-p123.link",
@@ -134,14 +138,16 @@ func TestBuildPrivateLinkListRows_TwoPrivateLinksDifferentRegions(t *testing.T) 
 
 	assert.Equal(t, "us-east-1", rows[0][2])
 	assert.Equal(t, "eu-west-1", rows[1][2])
-	assert.Equal(t, "com.amazonaws.vpce.us-east-1.vpce-svc-abc123", rows[0][4])
-	assert.Equal(t, "com.amazonaws.vpce.eu-west-1.vpce-svc-def456", rows[1][4])
-	assert.Equal(t, "orders-db-p123.link", rows[0][5])
-	assert.Equal(t, "cache-p123.link", rows[1][5])
-	assert.Equal(t, "Healthy", rows[0][6])
-	assert.Equal(t, "Healthy", rows[1][6])
-	assert.Equal(t, "-", rows[0][8])
-	assert.Equal(t, "-", rows[1][8])
+	assert.Equal(t, "us-east-1", rows[0][3])
+	assert.Equal(t, "eu-west-1", rows[1][3])
+	assert.Equal(t, "com.amazonaws.vpce.us-east-1.vpce-svc-abc123", rows[0][5])
+	assert.Equal(t, "com.amazonaws.vpce.eu-west-1.vpce-svc-def456", rows[1][5])
+	assert.Equal(t, "orders-db-p123.link", rows[0][6])
+	assert.Equal(t, "cache-p123.link", rows[1][6])
+	assert.Equal(t, "Healthy", rows[0][7])
+	assert.Equal(t, "Healthy", rows[1][7])
+	assert.Equal(t, "-", rows[0][9])
+	assert.Equal(t, "-", rows[1][9])
 }
 
 func TestFormatPrivateLinkHealthStatus(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-task/task/v3 v3.49.1
 	github.com/google/go-querystring v1.2.0
 	github.com/joho/godotenv v1.5.1
-	github.com/livekit/protocol v1.45.4-0.20260417165950-df0615eb700a
+	github.com/livekit/protocol v1.45.4-0.20260417173102-5d4f88f73b7c
 	github.com/livekit/server-sdk-go/v2 v2.16.2
 	github.com/mattn/go-isatty v0.0.21
 	github.com/moby/patternmatcher v0.6.1

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-task/task/v3 v3.49.1
 	github.com/google/go-querystring v1.2.0
 	github.com/joho/godotenv v1.5.1
-	github.com/livekit/protocol v1.45.4-0.20260414175434-28604d1045cd
+	github.com/livekit/protocol v1.45.4-0.20260417165950-df0615eb700a
 	github.com/livekit/server-sdk-go/v2 v2.16.2
 	github.com/mattn/go-isatty v0.0.21
 	github.com/moby/patternmatcher v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -363,6 +363,8 @@ github.com/livekit/protocol v1.45.4-0.20260414175434-28604d1045cd h1:T6z+yCaQGs8
 github.com/livekit/protocol v1.45.4-0.20260414175434-28604d1045cd/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/protocol v1.45.4-0.20260417165950-df0615eb700a h1:w4uHb432qHLCbyLoCHzaVwiVXvh6sCeHTkF7hIM8S9I=
 github.com/livekit/protocol v1.45.4-0.20260417165950-df0615eb700a/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
+github.com/livekit/protocol v1.45.4-0.20260417173102-5d4f88f73b7c h1:TusqCkqnqw/9B6BVJhFjFI8D/1Zy6z4oBsk1ehbpZIc=
+github.com/livekit/protocol v1.45.4-0.20260417173102-5d4f88f73b7c/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/psrpc v0.7.1 h1:ms37az0QTD3UXIWuUC5D/SkmKOlRMVRsI261eBWu/Vw=
 github.com/livekit/psrpc v0.7.1/go.mod h1:bZ4iHFQptTkbPnB0LasvRNu/OBYXEu1NA6O5BMFo9kk=
 github.com/livekit/server-sdk-go/v2 v2.16.2 h1:eQe24cka3X+5zUivezyL72nwtAJTWFXgibeiyJ/Jm+Y=

--- a/go.sum
+++ b/go.sum
@@ -361,6 +361,8 @@ github.com/livekit/mediatransportutil v0.0.0-20260309115634-0e2e24b36ee8 h1:coWi
 github.com/livekit/mediatransportutil v0.0.0-20260309115634-0e2e24b36ee8/go.mod h1:RCd46PT+6sEztld6XpkCrG1xskb0u3SqxIjy4G897Ss=
 github.com/livekit/protocol v1.45.4-0.20260414175434-28604d1045cd h1:T6z+yCaQGs8C+fSWXo8ZfM2qUyEpoC6Fbaa/dR3JodU=
 github.com/livekit/protocol v1.45.4-0.20260414175434-28604d1045cd/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
+github.com/livekit/protocol v1.45.4-0.20260417165950-df0615eb700a h1:w4uHb432qHLCbyLoCHzaVwiVXvh6sCeHTkF7hIM8S9I=
+github.com/livekit/protocol v1.45.4-0.20260417165950-df0615eb700a/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/psrpc v0.7.1 h1:ms37az0QTD3UXIWuUC5D/SkmKOlRMVRsI261eBWu/Vw=
 github.com/livekit/psrpc v0.7.1/go.mod h1:bZ4iHFQptTkbPnB0LasvRNu/OBYXEu1NA6O5BMFo9kk=
 github.com/livekit/server-sdk-go/v2 v2.16.2 h1:eQe24cka3X+5zUivezyL72nwtAJTWFXgibeiyJ/Jm+Y=


### PR DESCRIPTION
## Summary
- Adds a **Cloud Region** column to the `lk agent private-link list` table, positioned between `Region` and `Port`.
- Prints `Cloud Region [...]` after `lk agent private-link create` when the response includes one.

## Motivation
`cloud_region` is now returned on the `PrivateLink` proto, so surface it in the CLI so users can see which cloud provider region (e.g. `us-east-2`, `eastus`) their private link is on.

## Dependencies
- Requires [livekit/protocol#1503](https://github.com/livekit/protocol/pull/1503) (adds `PrivateLink.cloud_region`). This PR will need a `go.mod` bump to the new protocol pseudo-version after that lands.

## Test plan
- [ ] `go test ./cmd/lk/ -run PrivateLink` passes
- [ ] `lk agent private-link list` shows the new column
- [ ] `lk agent private-link create --cloud-region ...` prints Cloud Region line