### PR TITLE
Fix publishers flag on egress test-template command in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ lk egress test-template \
   --base-url http://localhost:3000 \
   --room test-room \
   --layout speaker \
-  --video-publishers 3
+  --publishers 3
 ```
 
 This command will launch a browser pointed at `http://localhost:3000`, while simulating 3 publishers publishing to your livekit instance.


### PR DESCRIPTION
The ReadMe incorrectly specifies `--video-publishers` for the `egress test-template` command, whereas it should be `--publishers`

Note that docs.livekit.io is correct, e.g. this page https://docs.livekit.io/transport/media/ingress-egress/egress/custom-template/#example specifies `--publishers` 