### PR TITLE
Enable Python bytecode compilation in UV for faster cold starts

### DIFF
--- a/pkg/agentfs/examples/python.uv.Dockerfile
+++ b/pkg/agentfs/examples/python.uv.Dockerfile
@@ -12,6 +12,11 @@ FROM ghcr.io/astral-sh/uv:python${PYTHON_VERSION}-bookworm-slim AS base
 # the application crashes without emitting any logs due to buffering.
 ENV PYTHONUNBUFFERED=1
 
+# Compile Python source to bytecode (.pyc) during install so the first import
+# doesn't pay the compilation cost. This reduces agent cold-start time at the
+# expense of a slightly longer build.
+ENV UV_COMPILE_BYTECODE=1
+
 # --- Build stage ---
 # Install dependencies, build native extensions, and prepare the application
 FROM base AS build


### PR DESCRIPTION
## Summary
This change enables Python bytecode compilation during the UV package installation phase to reduce agent cold-start time by pre-compiling Python source files to `.pyc` format.

## Key Changes
- Added `UV_COMPILE_BYTECODE=1` environment variable to the Docker base stage
- This causes UV to compile all Python source code to bytecode during the build phase rather than at first import

## Implementation Details
By pre-compiling Python source to bytecode during the Docker build, the first import of Python modules no longer incurs the compilation cost. This trades a slightly longer build time for significantly faster agent startup, which is beneficial for cold-start scenarios. The change is applied in the base stage so it affects all subsequent build stages.

https://claude.ai/code/session_01UD9HXN6LC1bHa9c8D2EVHN