### PR TITLE
fix: guard ServerRegions/AgentDeployments slice access in agent log streaming

### DIFF
--- a/cmd/lk/agent.go
+++ b/cmd/lk/agent.go
@@ -665,7 +665,11 @@ func createAgent(ctx context.Context, cmd *cli.Command) error {
 			return err
 		} else if viewLogs {
 			fmt.Println("Tailing runtime logs...safe to exit at any time")
-			return agentsClient.StreamLogs(ctx, "deploy", lkConfig.Agent.ID, os.Stdout, resp.ServerRegions[0])
+			logRegion := region
+			if len(resp.ServerRegions) > 0 {
+				logRegion = resp.ServerRegions[0]
+			}
+			return agentsClient.StreamLogs(ctx, "deploy", lkConfig.Agent.ID, os.Stdout, logRegion)
 		}
 	}
 	return nil
@@ -1013,6 +1017,9 @@ func getLogs(ctx context.Context, cmd *cli.Command) error {
 
 	if len(response.Agents) == 0 {
 		return fmt.Errorf("no agent deployments found")
+	}
+	if len(response.Agents[0].AgentDeployments) == 0 {
+		return fmt.Errorf("agent has no deployments to stream logs from")
 	}
 
 	return agentsClient.StreamLogs(ctx, cmd.String("log-type"), agentID, os.Stdout, response.Agents[0].AgentDeployments[0].ServerRegion)


### PR DESCRIPTION
## Problem
On v2.16.2, `lk agent create .` panics immediately after a successful build/deploy if you accept the post-deploy "view logs?" prompt:

```
Created agent with ID [agt-xxxxxxxxxxxx]
Build completed - You can view build logs later with `lk agent logs --log-type=build`
? Agent deploying. Would you like to view logs? Yes
Tailing runtime logs...safe to exit at any time
panic: runtime error: index out of range [0] with length 0
        github.com/livekit/livekit-cli/v2/cmd/lk/agent.go:646
```

The agent itself deploys fine — the crash is in the post-deploy log-tailer — so it's cosmetic, but it's a jarring stack trace at the end of an otherwise successful flow.

## Diagnosis
Two unguarded slice indexes in `cmd/lk/agent.go`:

1. **Line 646 (the panic):** the region for log streaming is read from the first element of the `CreateAgent` response's `ServerRegions` slice without a length check. When the server returns an empty `ServerRegions`, the CLI panics.
2. **Line 956 (latent, same class):** the `agent logs` subcommand checks that the `Agents` slice from `ListAgents` is non-empty, but then unconditionally reads `AgentDeployments[0]` on the first agent. An agent with zero deployments would panic the same way.

## Fix

**`cmd/lk/agent.go:646` — before:**
```go
} else if viewLogs {
    fmt.Println("Tailing runtime logs...safe to exit at any time")
    return agentsClient.StreamLogs(ctx, "deploy", lkConfig.Agent.ID, os.Stdout, resp.ServerRegions[0])
}
```

**after:**
```go
} else if viewLogs {
    fmt.Println("Tailing runtime logs...safe to exit at any time")
    logRegion := region
    if len(resp.ServerRegions) > 0 {
        logRegion = resp.ServerRegions[0]
    }
    return agentsClient.StreamLogs(ctx, "deploy", lkConfig.Agent.ID, os.Stdout, logRegion)
}
```
`region` is already resolved earlier in `createAgent` and is the region the build was targeted at — a sensible fallback for log streaming.

**`cmd/lk/agent.go:956` — before:**
```go
if len(response.Agents) == 0 {
    return fmt.Errorf("no agent deployments found")
}

return agentsClient.StreamLogs(ctx, cmd.String("log-type"), agentID, os.Stdout, response.Agents[0].AgentDeployments[0].ServerRegion)
```

**after:**
```go
if len(response.Agents) == 0 {
    return fmt.Errorf("no agent deployments found")
}
if len(response.Agents[0].AgentDeployments) == 0 {
    return fmt.Errorf("agent has no deployments to stream logs from")
}

return agentsClient.StreamLogs(ctx, cmd.String("log-type"), agentID, os.Stdout, response.Agents[0].AgentDeployments[0].ServerRegion)
```

## Definition of Done
- [ ] `lk agent create .` → accept "view logs?" prompt → no panic, even when the `CreateAgent` response has an empty `ServerRegions`
- [ ] `lk agent logs` against an agent with zero deployments → returns a clear error instead of panicking