### PR TITLE
cmd/lk: add --id flag to agent deploy command

### DIFF
--- a/cmd/lk/agent.go
+++ b/cmd/lk/agent.go
@@ -223,6 +223,7 @@ var (
 					Before: createAgentClient,
 					Action: deployAgent,
 					Flags: []cli.Flag{
+						idFlag(false),
 						secretsFlag,
 						secretsFileFlag,
 						secretsMountFlag,


### PR DESCRIPTION
The `deploy` subcommand calls `getAgentID()` which reads `cmd.String("id")`, but `--id` was never registered in the deploy command's `Flags` slice. Running `lk agent deploy --id CA_XXX` fails immediately at flag parse time with `flag provided but not defined: --id`.

Every other subcommand that uses `getAgentID()` (status, restart, rollback, update-secrets, config) already has `idFlag(false)` in its flags. Deploy was just missing it.

One-line fix: add `idFlag(false)` to the deploy Flags slice. `getAgentID()` already handles the `--id` → `livekit.toml` fallback logic, so no other changes needed.

This unblocks CI/CD workflows where the agent ID comes from a secrets manager or environment variable rather than a committed `livekit.toml`.

Fixes #830