### PR TITLE
install: create GOBIN directory if it doesn't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ cli: check_lfs
 
 
 install: cli
+	mkdir -p $(GOBIN)
 ifeq ($(DETECTED_OS),Windows)
 	cp bin/lk.exe $(GOBIN)/lk.exe
 	ln -sf $(GOBIN)/lk.exe $(GOBIN)/livekit-cli.exe


### PR DESCRIPTION
Fixes #818.

`make install` fails on fresh environments where GOBIN doesn't exist yet. The `cp` just errors out immediately. Adding `mkdir -p $(GOBIN)` before the copy so it works out of the box.

Easy to reproduce: set `GOBIN` to a path that doesn't exist and run `make install`.