### PR TITLE
token create: don't show default localhost URL in output

### DIFF
--- a/cmd/lk/token.go
+++ b/cmd/lk/token.go
@@ -457,9 +457,16 @@ func createToken(ctx context.Context, c *cli.Command) error {
 		return err
 	}
 
+	// The --url flag defaults to localhost:7880, so don't display it unless
+	// the user actually configured a URL.
+	projectURL := project.URL
+	if !c.IsSet("url") && projectURL == "http://localhost:7880" {
+		projectURL = ""
+	}
+
 	if err = printTokenCreateOutput(stdout, tokenOnly, jsonOutput, tokenCreateOutput{
 		AccessToken: token,
-		ProjectURL:  project.URL,
+		ProjectURL:  projectURL,
 		Identity:    participant,
 		Name:        name,
 		Room:        room,


### PR DESCRIPTION
Fixes #800.

The `--url` flag defaults to `http://localhost:7880` for dev convenience, but that default was getting printed as "Project URL" in `lk token create` output even when the user never configured a URL. Confusing, since it implies the token is tied to that server when really it isn't.

Now we skip the "Project URL" line if the URL wasn't explicitly set. If the user passes `--url` or sets `LIVEKIT_URL`, it still shows up as before.

Before:
```
Project URL: http://localhost:7880
Access token: eyJ...
```

After (when no URL configured):
```
Access token: eyJ...
```