### PR TITLE
fix: simulate dashboard URL + anchor lk gitignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@ dist/
 .task/
 
 .DS_Store
-lk
+/lk

--- a/cmd/lk/simulate.go
+++ b/cmd/lk/simulate.go
@@ -321,7 +321,7 @@ func simulationDashboardURL(projectID, runID string) string {
 	if projectID == "" || runID == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s/projects/%s/agents/simulations/%s", dashboardURL, projectID, runID)
+	return fmt.Sprintf("%s/projects/%s/evaluations/simulations/%s", dashboardURL, projectID, runID)
 }
 
 func cancelSimulationRun(client *lksdk.AgentSimulationClient, runID string) {


### PR DESCRIPTION
## Summary

Two small fixes around `lk agent simulate`:

- **`simulationDashboardURL`** — the cloud dashboard route is `/projects/{id}/evaluations/simulations/{runID}`, not `/agents/simulations/{runID}`. Confirmed against `livekit/web` (`apps/cloud/lib/paths.test.ts`). The link printed by `lk agent simulate` was 404ing on both prod and staging.

- **`.gitignore`** — the `lk` rule is unanchored, so it accidentally matches the `cmd/lk/` source directory and refuses `git add cmd/lk/<file>` even though the files inside are already tracked. Changed to `/lk` so it only matches the repo-root build artifact.

Each fix is a separate commit.

## Test plan

- [x] Ran `lk agent simulate -n 1 --dashboard-url https://cloud.staging.livekit.io --server-url https://cloud-api-server-public.ochicago1a.staging.livekit.app --project <staging>` against a real staging agent. Printed `Dashboard:` URL was `https://cloud.staging.livekit.io/projects/p_5v576e332p3/evaluations/simulations/SR_q95gb2aZ7c6v` (HTTP 401 logged-out, i.e. real page, not 404).
- [x] Edited `cmd/lk/simulate.go` in a clean working tree and ran `git add cmd/lk/simulate.go`; add succeeded (prior to this fix it would have been refused with "paths are ignored").