### PR TITLE
chore(build): bump base image for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25-alpine as builder
+FROM golang:1.26-alpine AS builder
 
 ARG TARGETPLATFORM
 ARG TARGETARCH


### PR DESCRIPTION
`go.mod` and some of our dependencies require go toolchain >= 1.26. This updates the base image in the Dockerfile to make sure that version is met.