### PR TITLE
Cache download-files in Dockerfile templates by using standalone commands

### DIFF
--- a/pkg/agentfs/examples/node.Dockerfile
+++ b/pkg/agentfs/examples/node.Dockerfile
@@ -34,6 +34,12 @@ COPY package.json pnpm-lock.yaml ./
 # --frozen-lockfile ensures we use exact versions from pnpm-lock.yaml for reproducible builds
 RUN pnpm install --frozen-lockfile
 
+# Pre-download any ML models or files the agent needs
+# This runs before COPY . . so the download layer is cached across code-only changes.
+# The standalone CLI discovers installed @livekit/agents-plugin-* packages without
+# loading your agent code.
+RUN npx livekit-agents download-files
+
 # Copy all remaining application files into the container
 # This includes source code, configuration files, and dependency specifications
 # (Excludes files specified in .dockerignore)
@@ -42,12 +48,6 @@ COPY . .
 # Build the project
 # Your package.json must contain a "build" script, such as `"build": "tsc"`
 RUN pnpm build
-
-# Pre-download any ML models or files the agent needs
-# This ensures the container is ready to run immediately without downloading
-# dependencies at runtime, which improves startup time and reliability
-# Your package.json must contain a "download-files" script, such as `"download-files": "pnpm run build && node dist/agent.js download-files"`
-RUN pnpm download-files
 
 # Remove dev dependencies for a leaner production image
 RUN pnpm prune --prod

--- a/pkg/agentfs/examples/python.pip.Dockerfile
+++ b/pkg/agentfs/examples/python.pip.Dockerfile
@@ -42,15 +42,16 @@ RUN python -m venv .venv
 ENV PATH="/app/.venv/bin:$PATH"
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Pre-download any ML models or files the agent needs
+# This runs before COPY . . so the download layer is cached across code-only changes.
+# The module-level command discovers installed livekit-plugins-* packages without
+# loading your agent code.
+RUN python -m livekit.agents download-files
+
 # Copy all remaining application files into the container
 # This includes source code, configuration files, and dependency specifications
 # (Excludes files specified in .dockerignore)
 COPY . .
-
-# Pre-download any ML models or files the agent needs
-# This ensures the container is ready to run immediately without downloading
-# dependencies at runtime, which improves startup time and reliability
-RUN python "{{.ProgramMain}}" download-files
 
 # --- Production stage ---
 # Build tools (gcc, g++, python3-dev) are not included in the final image

--- a/pkg/agentfs/examples/python.uv.Dockerfile
+++ b/pkg/agentfs/examples/python.uv.Dockerfile
@@ -46,15 +46,16 @@ RUN mkdir -p src
 # Ensure your uv.lock file is checked in for consistency across environments
 RUN uv sync --locked
 
+# Pre-download any ML models or files the agent needs
+# This runs before COPY . . so the download layer is cached across code-only changes.
+# The module-level command discovers installed livekit-plugins-* packages without
+# loading your agent code.
+RUN uv run --module livekit.agents download-files
+
 # Copy all remaining application files into the container
 # This includes source code, configuration files, and dependency specifications
 # (Excludes files specified in .dockerignore)
 COPY . .
-
-# Pre-download any ML models or files the agent needs
-# This ensures the container is ready to run immediately without downloading
-# dependencies at runtime, which improves startup time and reliability
-RUN uv run "{{.ProgramMain}}" download-files
 
 # --- Production stage ---
 # Build tools (gcc, g++, python3-dev) are not included in the final image


### PR DESCRIPTION
## Overview

Update the three Dockerfile templates in `pkg/agentfs/examples/` to use the standalone `download-files` commands that ship in `livekit-agents@1.5.10` (Python) and `@livekit/agents@1.4.3` (Node.js). The download step now runs before `COPY . .`, so the layer caches across code-only changes — editing your agent no longer triggers a re-download of plugin model files.

## Changes

- **`node.Dockerfile`** — `RUN pnpm download-files` (after `pnpm build`, after `COPY . .`) → `RUN npx livekit-agents download-files` (before `COPY . .`). Drops the requirement that the user's `package.json` define a `download-files` script.
- **`python.uv.Dockerfile`** — `RUN uv run "{{.ProgramMain}}" download-files` (after `COPY . .`) → `RUN uv run --module livekit.agents download-files` (before `COPY . .`).
- **`python.pip.Dockerfile`** — `RUN python "{{.ProgramMain}}" download-files` (after `COPY . .`) → `RUN python -m livekit.agents download-files` (before `COPY . .`).

The new commands discover installed plugin packages (`livekit-plugins-*` for Python, `@livekit/agents-plugin-*` for Node.js) and run their `download_files()` step without loading the user's agent code. That's what allows the step to move ahead of the source copy.

## Compatibility

These templates are rendered by the CLI when scaffolding a new agent project (`lk agent init`). Existing users running older SDK versions won't see this change until they regenerate. The old `agent.py download-files` / `node dist/agent.js download-files` forms still work in newer SDKs but emit a deprecation warning.

## Related PRs

This is part of a coordinated rollout across five repos. Each PR updates one slice of the same migration.

- Docs: livekit/web#4545
- CLI templates (this PR): livekit/livekit-cli#848
- Python starter: livekit-examples/agent-starter-python#79
- Node.js starter: livekit-examples/agent-starter-node#49
- Agent builder export: livekit/cloud-api-server#1847

Upstream SDK changes:

- Python: livekit/agents#5738 (livekit-agents@1.5.10)
- Node.js: livekit/agents-js#1511 (@livekit/agents@1.4.3)

