### PR TITLE
refactor(cli): make agent spawn/detect helpers CGO-free

### DIFF
--- a/cmd/lk/agent_run.go
+++ b/cmd/lk/agent_run.go
@@ -22,13 +22,10 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"sync"
 	"syscall"
 
 	"github.com/urfave/cli/v3"
-
-	"github.com/livekit/livekit-cli/v2/pkg/agentfs"
 )
 
 func init() {
@@ -107,45 +104,6 @@ func resolveCredentials(cmd *cli.Command, loadOpts ...loadOption) ([]string, err
 		args = append(args, "--api-secret", apiSecret)
 	}
 	return args, nil
-}
-
-func detectProject(cmd *cli.Command) (string, agentfs.ProjectType, string, error) {
-	explicit := cmd.Args().First()
-
-	detectFrom := "."
-	if explicit != "" {
-		absPath, err := filepath.Abs(explicit)
-		if err != nil {
-			return "", "", "", err
-		}
-		if _, err := os.Stat(absPath); err != nil {
-			return "", "", "", fmt.Errorf("entrypoint file not found: %s", explicit)
-		}
-		detectFrom = filepath.Dir(absPath)
-	}
-
-	projectDir, projectType, err := agentfs.DetectProjectRoot(detectFrom)
-	if err != nil {
-		return "", "", "", noAgentError()
-	}
-	if !projectType.IsPython() {
-		return "", "", "", fmt.Errorf("currently only supports Python agents (detected: %s)", projectType)
-	}
-
-	if explicit != "" {
-		absPath, _ := filepath.Abs(explicit)
-		rel, err := filepath.Rel(projectDir, absPath)
-		if err != nil {
-			return "", "", "", fmt.Errorf("entrypoint %s is outside project root %s", explicit, projectDir)
-		}
-		return projectDir, projectType, rel, nil
-	}
-
-	entrypoint, err := findEntrypoint(projectDir, "", projectType)
-	if err != nil {
-		return "", "", "", err
-	}
-	return projectDir, projectType, entrypoint, nil
 }
 
 func buildCLIArgs(subcmd string, cmd *cli.Command, loadOpts ...loadOption) ([]string, error) {

--- a/cmd/lk/agent_utils.go
+++ b/cmd/lk/agent_utils.go
@@ -1,0 +1,81 @@
+// Copyright 2025 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/livekit/livekit-cli/v2/pkg/agentfs"
+)
+
+// detectProject resolves which agent to run from the CLI args: the project
+// directory, its type, and the entrypoint (explicit file or auto-discovered).
+func detectProject(cmd *cli.Command) (string, agentfs.ProjectType, string, error) {
+	explicit := cmd.Args().First()
+
+	detectFrom := "."
+	if explicit != "" {
+		absPath, err := filepath.Abs(explicit)
+		if err != nil {
+			return "", "", "", err
+		}
+		if _, err := os.Stat(absPath); err != nil {
+			return "", "", "", fmt.Errorf("entrypoint file not found: %s", explicit)
+		}
+		detectFrom = filepath.Dir(absPath)
+	}
+
+	projectDir, projectType, err := agentfs.DetectProjectRoot(detectFrom)
+	if err != nil {
+		return "", "", "", noAgentError()
+	}
+
+	// TODO(node): support JS/Node agents here. DetectProjectRoot already
+	// recognizes Node projects; once the session daemon can spawn a Node
+	// agent in console mode, drop this gate and branch on projectType.
+	if !projectType.IsPython() {
+		return "", "", "", fmt.Errorf("currently only supports Python agents (detected: %s)", projectType)
+	}
+
+	if explicit != "" {
+		absPath, _ := filepath.Abs(explicit)
+		rel, err := filepath.Rel(projectDir, absPath)
+		if err != nil {
+			return "", "", "", fmt.Errorf("entrypoint %s is outside project root %s", explicit, projectDir)
+		}
+		return projectDir, projectType, rel, nil
+	}
+
+	entrypoint, err := findEntrypoint(projectDir, "", projectType)
+	if err != nil {
+		return "", "", "", err
+	}
+	return projectDir, projectType, entrypoint, nil
+}
+
+// buildConsoleArgs builds the agent subprocess argv that connects back over TCP
+// in console mode. Shared by `lk agent console` (mic/speaker) and the headless
+// `lk session` daemon.
+func buildConsoleArgs(addr string, record bool) []string {
+	args := []string{"console", "--connect-addr", addr}
+	if record {
+		args = append(args, "--record")
+	}
+	return args
+}

--- a/cmd/lk/agent_utils.go
+++ b/cmd/lk/agent_utils.go
@@ -24,8 +24,6 @@ import (
 	"github.com/livekit/livekit-cli/v2/pkg/agentfs"
 )
 
-// detectProject resolves which agent to run from the CLI args: the project
-// directory, its type, and the entrypoint (explicit file or auto-discovered).
 func detectProject(cmd *cli.Command) (string, agentfs.ProjectType, string, error) {
 	explicit := cmd.Args().First()
 
@@ -69,9 +67,8 @@ func detectProject(cmd *cli.Command) (string, agentfs.ProjectType, string, error
 	return projectDir, projectType, entrypoint, nil
 }
 
-// buildConsoleArgs builds the agent subprocess argv that connects back over TCP
-// in console mode. Shared by `lk agent console` (mic/speaker) and the headless
-// `lk session` daemon.
+// buildConsoleArgs builds the agent subprocess argv for console mode, shared by
+// `lk agent console` and the `lk session` daemon.
 func buildConsoleArgs(addr string, record bool) []string {
 	args := []string{"console", "--connect-addr", addr}
 	if record {

--- a/cmd/lk/agent_utils.go
+++ b/cmd/lk/agent_utils.go
@@ -14,6 +14,8 @@
 
 package main
 
+//lint:file-ignore U1000 consumed by console-tagged commands (hidden from the default tag-free lint build) and the lk session daemon (follow-up PR); remove once the daemon merges
+
 import (
 	"fmt"
 	"os"

--- a/cmd/lk/console.go
+++ b/cmd/lk/console.go
@@ -236,14 +236,6 @@ func runConsole(ctx context.Context, cmd *cli.Command) error {
 	return nil
 }
 
-func buildConsoleArgs(addr string, record bool) []string {
-	args := []string{"console", "--connect-addr", addr}
-	if record {
-		args = append(args, "--record")
-	}
-	return args
-}
-
 func listDevices() error {
 	devices, err := portaudio.ListDevices()
 	if err != nil {
@@ -282,4 +274,3 @@ func listDevices() error {
 
 	return nil
 }
-

--- a/cmd/lk/proc_unix.go
+++ b/cmd/lk/proc_unix.go
@@ -2,6 +2,8 @@
 
 package main
 
+//lint:file-ignore U1000 consumed by console-tagged commands (hidden from the default tag-free lint build) and the lk session daemon (follow-up PR); remove once the daemon merges
+
 import (
 	"os/exec"
 	"syscall"

--- a/cmd/lk/proc_unix.go
+++ b/cmd/lk/proc_unix.go
@@ -1,4 +1,4 @@
-//go:build console && !windows
+//go:build !windows
 
 package main
 
@@ -9,6 +9,12 @@ import (
 
 func setProcAttr(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// setDetachedProcAttr puts the child in its own session so it survives the
+// parent CLI invocation exiting (used for the detached session daemon).
+func setDetachedProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 }
 
 // sendInterrupt sends SIGINT to the entire process group.

--- a/cmd/lk/proc_windows.go
+++ b/cmd/lk/proc_windows.go
@@ -1,4 +1,4 @@
-//go:build console && windows
+//go:build windows
 
 package main
 
@@ -6,9 +6,16 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"syscall"
 )
 
 func setProcAttr(_ *exec.Cmd) {}
+
+// setDetachedProcAttr starts the daemon in a new process group so it is not
+// killed when the parent CLI invocation exits.
+func setDetachedProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+}
 
 func (ap *AgentProcess) sendInterrupt() {
 	if ap.cmd.Process != nil {

--- a/cmd/lk/simulate_subprocess.go
+++ b/cmd/lk/simulate_subprocess.go
@@ -14,6 +14,8 @@
 
 package main
 
+//lint:file-ignore U1000 consumed by console-tagged commands (hidden from the default tag-free lint build) and the lk session daemon (follow-up PR); remove once the daemon merges
+
 import (
 	"bufio"
 	"encoding/json"

--- a/cmd/lk/simulate_subprocess.go
+++ b/cmd/lk/simulate_subprocess.go
@@ -1,5 +1,3 @@
-//go:build console
-
 // Copyright 2025 LiveKit, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +36,7 @@ type AgentProcess struct {
 	readyCh        chan struct{}
 	doneCh         chan error
 	exitCh         chan struct{} // closed when process exits, safe to read multiple times
-	shutdownCalled bool         // true after Shutdown() sends SIGINT
+	shutdownCalled bool          // true after Shutdown() sends SIGINT
 
 	// LogStream receives log lines in real-time. Nil if not needed.
 	LogStream chan string


### PR DESCRIPTION
## Summary

Pure refactor (no behavior change) that moves the agent **spawn/detect** logic out from under the `console` build tag so it can be reused by the default, CGO-free `lk` binary. This is enabling work for an upcoming `lk session` daemon — split out as its own PR so the diff is reviewable as a mechanical code move.

## Why

The default `lk` binary is CGO-free. The `console` build tag pulls in PortAudio + the WebRTC APM (CGO). But the logic to (a) detect which agent project to run, (b) build the agent's `console --connect-addr …` argv, and (c) spawn/signal the subprocess is all **pure Go** — it was only gated behind `console` because it happened to live next to the console command. Leaving it there would force any CGO-free consumer to either duplicate it or drag in PortAudio.

The dividing line drawn here: **spawn/detect = pure Go (untagged); mic/speaker/APM = CGO (stays tagged).** No audio/CGO code is moved out of the tag.

## What changed

- **`simulate_subprocess.go`** — dropped `//go:build console`. Holds `AgentProcess` + `findPythonBinary`/`findEntrypoint`/`startAgent`; all stdlib + `pkg/agentfs`, no CGO.
- **`proc_unix.go` / `proc_windows.go`** — retagged `console && <os>` → `<os>`. Forced by the above: the now-untagged spawner calls `setProcAttr` and `AgentProcess.sendInterrupt/sendKill/sendShutdown`, which live here. Also adds **`setDetachedProcAttr`** (`Setsid` on Unix / `CREATE_NEW_PROCESS_GROUP` on Windows) for detaching the future daemon.
- **`agent_utils.go`** (new, untagged) — extracts `detectProject` and `buildConsoleArgs` verbatim out of the console-tagged `agent_run.go` / `console.go`, so they're shared by `lk agent console` and the future `lk session`.
- **`agent_run.go` / `console.go`** — delete the moved functions and the now-unused imports (`path/filepath`, `pkg/agentfs`). Both keep their `console` tag.

## Notes for reviewers

- **Zero behavior change.** Every moved function is byte-for-byte identical; nothing is rewired. `detectProject`/`buildConsoleArgs` show as delete+add (not git renames) because they were extracted, not whole-file moved.
- **`setDetachedProcAttr` is currently unused** — it lands here with the other proc helpers and is consumed by the session daemon in a later PR.
- A `TODO(node)` marks the single `IsPython()` gate in `detectProject` (the `agentfs` layer already models Node fully).

## Test plan

- [x] `CGO_ENABLED=0 go build ./cmd/lk/` (default) — green
- [x] `CGO_ENABLED=1 go build -tags console ./cmd/lk/` (CGO) — green
- [x] `GOOS=windows CGO_ENABLED=0 go build ./cmd/lk/` (Windows cross-compile) — green
- [x] `lk` gains no new commands