### PR TITLE
refactor(console): untag TCPServer and add AcceptConn for multi-connection use

### DIFF
--- a/cmd/lk/agent_run.go
+++ b/cmd/lk/agent_run.go
@@ -22,13 +22,10 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"sync"
 	"syscall"
 
 	"github.com/urfave/cli/v3"
-
-	"github.com/livekit/livekit-cli/v2/pkg/agentfs"
 )
 
 func init() {
@@ -107,45 +104,6 @@ func resolveCredentials(cmd *cli.Command, loadOpts ...loadOption) ([]string, err
 		args = append(args, "--api-secret", apiSecret)
 	}
 	return args, nil
-}
-
-func detectProject(cmd *cli.Command) (string, agentfs.ProjectType, string, error) {
-	explicit := cmd.Args().First()
-
-	detectFrom := "."
-	if explicit != "" {
-		absPath, err := filepath.Abs(explicit)
-		if err != nil {
-			return "", "", "", err
-		}
-		if _, err := os.Stat(absPath); err != nil {
-			return "", "", "", fmt.Errorf("entrypoint file not found: %s", explicit)
-		}
-		detectFrom = filepath.Dir(absPath)
-	}
-
-	projectDir, projectType, err := agentfs.DetectProjectRoot(detectFrom)
-	if err != nil {
-		return "", "", "", noAgentError()
-	}
-	if !projectType.IsPython() {
-		return "", "", "", fmt.Errorf("currently only supports Python agents (detected: %s)", projectType)
-	}
-
-	if explicit != "" {
-		absPath, _ := filepath.Abs(explicit)
-		rel, err := filepath.Rel(projectDir, absPath)
-		if err != nil {
-			return "", "", "", fmt.Errorf("entrypoint %s is outside project root %s", explicit, projectDir)
-		}
-		return projectDir, projectType, rel, nil
-	}
-
-	entrypoint, err := findEntrypoint(projectDir, "", projectType)
-	if err != nil {
-		return "", "", "", err
-	}
-	return projectDir, projectType, entrypoint, nil
 }
 
 func buildCLIArgs(subcmd string, cmd *cli.Command, loadOpts ...loadOption) ([]string, error) {

--- a/cmd/lk/agent_utils.go
+++ b/cmd/lk/agent_utils.go
@@ -1,0 +1,81 @@
+// Copyright 2025 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/livekit/livekit-cli/v2/pkg/agentfs"
+)
+
+// detectProject resolves which agent to run from the CLI args: the project
+// directory, its type, and the entrypoint (explicit file or auto-discovered).
+func detectProject(cmd *cli.Command) (string, agentfs.ProjectType, string, error) {
+	explicit := cmd.Args().First()
+
+	detectFrom := "."
+	if explicit != "" {
+		absPath, err := filepath.Abs(explicit)
+		if err != nil {
+			return "", "", "", err
+		}
+		if _, err := os.Stat(absPath); err != nil {
+			return "", "", "", fmt.Errorf("entrypoint file not found: %s", explicit)
+		}
+		detectFrom = filepath.Dir(absPath)
+	}
+
+	projectDir, projectType, err := agentfs.DetectProjectRoot(detectFrom)
+	if err != nil {
+		return "", "", "", noAgentError()
+	}
+
+	// TODO(node): support JS/Node agents here. DetectProjectRoot already
+	// recognizes Node projects; once the session daemon can spawn a Node
+	// agent in console mode, drop this gate and branch on projectType.
+	if !projectType.IsPython() {
+		return "", "", "", fmt.Errorf("currently only supports Python agents (detected: %s)", projectType)
+	}
+
+	if explicit != "" {
+		absPath, _ := filepath.Abs(explicit)
+		rel, err := filepath.Rel(projectDir, absPath)
+		if err != nil {
+			return "", "", "", fmt.Errorf("entrypoint %s is outside project root %s", explicit, projectDir)
+		}
+		return projectDir, projectType, rel, nil
+	}
+
+	entrypoint, err := findEntrypoint(projectDir, "", projectType)
+	if err != nil {
+		return "", "", "", err
+	}
+	return projectDir, projectType, entrypoint, nil
+}
+
+// buildConsoleArgs builds the agent subprocess argv that connects back over TCP
+// in console mode. Shared by `lk agent console` (mic/speaker) and the headless
+// `lk session` daemon.
+func buildConsoleArgs(addr string, record bool) []string {
+	args := []string{"console", "--connect-addr", addr}
+	if record {
+		args = append(args, "--record")
+	}
+	return args
+}

--- a/cmd/lk/agent_utils.go
+++ b/cmd/lk/agent_utils.go
@@ -24,8 +24,6 @@ import (
 	"github.com/livekit/livekit-cli/v2/pkg/agentfs"
 )
 
-// detectProject resolves which agent to run from the CLI args: the project
-// directory, its type, and the entrypoint (explicit file or auto-discovered).
 func detectProject(cmd *cli.Command) (string, agentfs.ProjectType, string, error) {
 	explicit := cmd.Args().First()
 
@@ -69,9 +67,8 @@ func detectProject(cmd *cli.Command) (string, agentfs.ProjectType, string, error
 	return projectDir, projectType, entrypoint, nil
 }
 
-// buildConsoleArgs builds the agent subprocess argv that connects back over TCP
-// in console mode. Shared by `lk agent console` (mic/speaker) and the headless
-// `lk session` daemon.
+// buildConsoleArgs builds the agent subprocess argv for console mode, shared by
+// `lk agent console` and the `lk session` daemon.
 func buildConsoleArgs(addr string, record bool) []string {
 	args := []string{"console", "--connect-addr", addr}
 	if record {

--- a/cmd/lk/agent_utils.go
+++ b/cmd/lk/agent_utils.go
@@ -14,6 +14,8 @@
 
 package main
 
+//lint:file-ignore U1000 consumed by console-tagged commands (hidden from the default tag-free lint build) and the lk session daemon (follow-up PR); remove once the daemon merges
+
 import (
 	"fmt"
 	"os"

--- a/cmd/lk/console.go
+++ b/cmd/lk/console.go
@@ -236,14 +236,6 @@ func runConsole(ctx context.Context, cmd *cli.Command) error {
 	return nil
 }
 
-func buildConsoleArgs(addr string, record bool) []string {
-	args := []string{"console", "--connect-addr", addr}
-	if record {
-		args = append(args, "--record")
-	}
-	return args
-}
-
 func listDevices() error {
 	devices, err := portaudio.ListDevices()
 	if err != nil {
@@ -282,4 +274,3 @@ func listDevices() error {
 
 	return nil
 }
-

--- a/cmd/lk/proc_unix.go
+++ b/cmd/lk/proc_unix.go
@@ -2,6 +2,8 @@
 
 package main
 
+//lint:file-ignore U1000 consumed by console-tagged commands (hidden from the default tag-free lint build) and the lk session daemon (follow-up PR); remove once the daemon merges
+
 import (
 	"os/exec"
 	"syscall"

--- a/cmd/lk/proc_unix.go
+++ b/cmd/lk/proc_unix.go
@@ -1,4 +1,4 @@
-//go:build console && !windows
+//go:build !windows
 
 package main
 
@@ -9,6 +9,12 @@ import (
 
 func setProcAttr(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// setDetachedProcAttr puts the child in its own session so it survives the
+// parent CLI invocation exiting (used for the detached session daemon).
+func setDetachedProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 }
 
 // sendInterrupt sends SIGINT to the entire process group.

--- a/cmd/lk/proc_windows.go
+++ b/cmd/lk/proc_windows.go
@@ -1,4 +1,4 @@
-//go:build console && windows
+//go:build windows
 
 package main
 
@@ -6,9 +6,16 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"syscall"
 )
 
 func setProcAttr(_ *exec.Cmd) {}
+
+// setDetachedProcAttr starts the daemon in a new process group so it is not
+// killed when the parent CLI invocation exits.
+func setDetachedProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+}
 
 func (ap *AgentProcess) sendInterrupt() {
 	if ap.cmd.Process != nil {

--- a/cmd/lk/simulate_subprocess.go
+++ b/cmd/lk/simulate_subprocess.go
@@ -14,6 +14,8 @@
 
 package main
 
+//lint:file-ignore U1000 consumed by console-tagged commands (hidden from the default tag-free lint build) and the lk session daemon (follow-up PR); remove once the daemon merges
+
 import (
 	"bufio"
 	"encoding/json"

--- a/cmd/lk/simulate_subprocess.go
+++ b/cmd/lk/simulate_subprocess.go
@@ -1,5 +1,3 @@
-//go:build console
-
 // Copyright 2025 LiveKit, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +36,7 @@ type AgentProcess struct {
 	readyCh        chan struct{}
 	doneCh         chan error
 	exitCh         chan struct{} // closed when process exits, safe to read multiple times
-	shutdownCalled bool         // true after Shutdown() sends SIGINT
+	shutdownCalled bool          // true after Shutdown() sends SIGINT
 
 	// LogStream receives log lines in real-time. Nil if not needed.
 	LogStream chan string

--- a/pkg/console/tcp.go
+++ b/pkg/console/tcp.go
@@ -1,5 +1,3 @@
-//go:build console
-
 package console
 
 import (
@@ -52,6 +50,13 @@ func (s *TCPServer) Accept() (net.Conn, error) {
 	s.listener.Close()
 
 	return conn, nil
+}
+
+// AcceptConn returns the next connection without closing the listener, so the
+// server can keep accepting more. Used by the session daemon, which accepts
+// both the agent connection and many CLI control connections on one port.
+func (s *TCPServer) AcceptConn() (net.Conn, error) {
+	return s.listener.Accept()
 }
 
 // Conn returns the accepted connection, or nil if none.


### PR DESCRIPTION
## Summary

Makes the console TCP transport reusable by the CGO-free `lk` binary and adds a multi-connection accept path. Second PR in the stack enabling the upcoming `lk session` daemon.

> **Stacked on #855** (`refactor/agent-spawn-cgo-free`).

## Why

The session daemon needs to accept several connections on a single loopback port at once — the agent's protobuf connection **plus** every short-lived `lk session say`/`end` control connection. The existing `TCPServer` was built for `lk agent console`'s strict one-connection model, and was gated behind the `console` build tag (PortAudio/CGO).

## What changed (`pkg/console/tcp.go`, +7/-2)

- **Untag** — drop `//go:build console`. The transport is pure `pkg/ipc` framing (no PortAudio/APM); the audio guts (`pipeline.go`, `ringbuffer.go`, `fft.go`) stay `console`-tagged. Clean seam: transport is shareable, audio is not.
- **Add `AcceptConn()`** — returns the next connection **without** closing the listener, so the server keeps accepting. `Accept()` is untouched and stays single-shot (accept one agent, then `listener.Close()`), so `lk agent console` behavior is unchanged.

`Accept()` vs `AcceptConn()`:

| | `Accept()` | `AcceptConn()` |
|---|---|---|
| stores `s.conn` | yes | no |
| closes listener after first | yes | no |
| connections allowed | exactly 1 | many |

`AcceptConn` touches no shared state (no mutex needed); the daemon owns connection lifecycle and classifies each conn itself. `Close()` still cleans up correctly for both paths.

## Notes for reviewers

- No behavior change for `lk agent console` — `Accept()` is identical.
- `AcceptConn` is unused until the daemon PR. Unlike the helpers in #855, **no U1000 suppression is needed**: everything in `tcp.go` is exported, and staticcheck's `unused` only flags unexported symbols.

## Test plan

- [x] `staticcheck ./...` (no `console` tag, as CI runs it) — clean, exit 0
- [x] `CGO_ENABLED=0 go build ./...` (default) — green
- [x] `CGO_ENABLED=1 go build -tags console ./...` (CGO) — green