### PR TITLE
Remove trailing slash when building url

### DIFF
--- a/cmd/lk/egress.go
+++ b/cmd/lk/egress.go
@@ -778,7 +778,7 @@ func testEgressTemplate(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	templateURL := fmt.Sprintf(
-		"%s/?url=%s&layout=%s&token=%s",
+		"%s?url=%s&layout=%s&token=%s",
 		cmd.String("base-url"), url.QueryEscape(serverURL), cmd.String("layout"), token,
 	)
 	if err := browser.OpenURL(templateURL); err != nil {


### PR DESCRIPTION
This is host dependent, but providing `example.com/?url...` can be treated as a different path to `example.com?url...`.

Instead we rely on what ever the user provides as `base_url` and append the query params to that base url.