### PR TITLE
feat: update python Dockerfiles to use -m invocation of download-files

### DIFF
--- a/pkg/agentfs/examples/python.pip.Dockerfile
+++ b/pkg/agentfs/examples/python.pip.Dockerfile
@@ -50,7 +50,7 @@ COPY . .
 # Pre-download any ML models or files the agent needs
 # This ensures the container is ready to run immediately without downloading
 # dependencies at runtime, which improves startup time and reliability
-RUN python "{{.ProgramMain}}" download-files
+RUN python -m livekit.agents download-files
 
 # --- Production stage ---
 # Build tools (gcc, g++, python3-dev) are not included in the final image

--- a/pkg/agentfs/examples/python.uv.Dockerfile
+++ b/pkg/agentfs/examples/python.uv.Dockerfile
@@ -54,7 +54,7 @@ COPY . .
 # Pre-download any ML models or files the agent needs
 # This ensures the container is ready to run immediately without downloading
 # dependencies at runtime, which improves startup time and reliability
-RUN uv run "{{.ProgramMain}}" download-files
+RUN uv run -m livekit.agents download-files
 
 # --- Production stage ---
 # Build tools (gcc, g++, python3-dev) are not included in the final image


### PR DESCRIPTION
Since direct invocation using `agent.py download-files` is now deprecated