### PR TITLE
simulate: --concurrency flag + launch the agent with --simulation

### DIFF
--- a/cmd/lk/simulate.go
+++ b/cmd/lk/simulate.go
@@ -73,6 +73,10 @@ var simulateCommand = &cli.Command{
 			Aliases: []string{"n"},
 			Usage:   "Number of scenarios to generate",
 		},
+		&cli.IntFlag{
+			Name:  "concurrency",
+			Usage: "Max simulations running in parallel (default: server-side limit)",
+		},
 		&cli.StringFlag{
 			Name:  "scenarios",
 			Usage: "Path to a scenarios `FILE` (yaml). If omitted, scenarios are generated from the agent's source",
@@ -158,6 +162,7 @@ type simulateConfig struct {
 	client         *lksdk.AgentSimulationClient
 	pc             *config.ProjectConfig
 	numSimulations int32
+	concurrency    int32
 	mode           simulateMode
 	agentName      string
 	projectDir     string
@@ -221,6 +226,7 @@ func runSimulate(ctx context.Context, cmd *cli.Command) error {
 	pc := simulateProjectConfig
 
 	numSimulations := int32(cmd.Int("num-simulations"))
+	concurrency := int32(cmd.Int("concurrency"))
 	agentName := generateAgentName()
 
 	projectDir, projectType, err := agentfs.DetectProjectRoot(".")
@@ -271,6 +277,7 @@ func runSimulate(ctx context.Context, cmd *cli.Command) error {
 		client:         simClient,
 		pc:             pc,
 		numSimulations: numSimulations,
+		concurrency:    concurrency,
 		mode:           mode,
 		agentName:      agentName,
 		projectDir:     projectDir,
@@ -341,6 +348,8 @@ func startSimulationAgent(c *simulateConfig, forwardOutput io.Writer) (*AgentPro
 			"--api-secret", c.pc.APISecret,
 			"--log-level", "DEBUG",
 			"--log-format", "colored",
+			// disable the worker load limit so the run can saturate the agent
+			"--simulation",
 		},
 		Env: []string{
 			// force the agent to register under the dispatch name regardless of any
@@ -360,6 +369,9 @@ func createSimulationRun(ctx context.Context, c *simulateConfig) (string, *livek
 	req := &livekit.SimulationRun_Create_Request{
 		AgentName:      c.agentName,
 		NumSimulations: c.numSimulations,
+	}
+	if c.concurrency > 0 {
+		req.Concurrency = &c.concurrency
 	}
 	if c.mode == modeScenarios {
 		// Run the scenarios from the yaml. When unset, the server generates

--- a/cmd/lk/simulate_ci.go
+++ b/cmd/lk/simulate_ci.go
@@ -320,8 +320,12 @@ func printCIResults(run *livekit.SimulationRun, agent *AgentProcess) {
 	if run.Summary != nil {
 		printCISummary(run)
 	} else {
+		msg := "The summary for this run is not available"
+		if run.Error != "" {
+			msg = run.Error
+		}
 		fmt.Fprintln(os.Stdout)
-		fmt.Fprintln(os.Stdout, "⚠ The summary for this run is not available")
+		fmt.Fprintln(os.Stdout, "⚠ "+msg)
 	}
 }
 

--- a/cmd/lk/simulate_tui.go
+++ b/cmd/lk/simulate_tui.go
@@ -1002,7 +1002,11 @@ func (m *simulateModel) viewRunning() string {
 		} else if m.run.Summary != nil {
 			b.WriteString(m.renderSummary())
 		} else if isTerminalRunStatus(m.run.Status) {
-			b.WriteString(fmt.Sprintf("\n  %s %s\n", yellowStyle.Render("⚠"), yellowStyle.Render("The summary for this run is not available")))
+			msg := "The summary for this run is not available"
+			if m.run.Error != "" {
+				msg = m.run.Error
+			}
+			b.WriteString(fmt.Sprintf("\n  %s %s\n", yellowStyle.Render("⚠"), yellowStyle.Render(msg)))
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-containerregistry v0.20.7
 	github.com/google/go-querystring v1.2.0
 	github.com/joho/godotenv v1.5.1
-	github.com/livekit/protocol v1.46.7-0.20260610052126-53915ab24d75
+	github.com/livekit/protocol v1.46.7-0.20260610173606-5e03f5ef0e6b
 	github.com/livekit/server-sdk-go/v2 v2.16.7-0.20260608025623-a5da15b13baa
 	github.com/mattn/go-isatty v0.0.22
 	github.com/moby/patternmatcher v0.6.1
@@ -248,7 +248,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20260603202125-055de637280b // indirect
-	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-containerregistry v0.20.7
 	github.com/google/go-querystring v1.2.0
 	github.com/joho/godotenv v1.5.1
-	github.com/livekit/protocol v1.46.7-0.20260610022548-4fedc9bff28c
+	github.com/livekit/protocol v1.46.7-0.20260610052126-53915ab24d75
 	github.com/livekit/server-sdk-go/v2 v2.16.7-0.20260608025623-a5da15b13baa
 	github.com/mattn/go-isatty v0.0.22
 	github.com/moby/patternmatcher v0.6.1
@@ -248,6 +248,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20260603202125-055de637280b // indirect
+	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-containerregistry v0.20.7
 	github.com/google/go-querystring v1.2.0
 	github.com/joho/godotenv v1.5.1
-	github.com/livekit/protocol v1.46.7-0.20260608020211-e9abadf97706
+	github.com/livekit/protocol v1.46.7-0.20260610022548-4fedc9bff28c
 	github.com/livekit/server-sdk-go/v2 v2.16.7-0.20260608025623-a5da15b13baa
 	github.com/mattn/go-isatty v0.0.22
 	github.com/moby/patternmatcher v0.6.1

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-containerregistry v0.20.7
 	github.com/google/go-querystring v1.2.0
 	github.com/joho/godotenv v1.5.1
-	github.com/livekit/protocol v1.46.7-0.20260610173606-5e03f5ef0e6b
+	github.com/livekit/protocol v1.46.7-0.20260610175657-3ccff51ebf5b
 	github.com/livekit/server-sdk-go/v2 v2.16.7-0.20260608025623-a5da15b13baa
 	github.com/mattn/go-isatty v0.0.22
 	github.com/moby/patternmatcher v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -359,6 +359,8 @@ github.com/livekit/mediatransportutil v0.0.0-20260605212259-862d4a7bcb1e h1:SkgQ
 github.com/livekit/mediatransportutil v0.0.0-20260605212259-862d4a7bcb1e/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
 github.com/livekit/protocol v1.46.7-0.20260610022548-4fedc9bff28c h1:v//f0TuRu07YHame/9yvjktOV1dq7RFuFwarcepZr/o=
 github.com/livekit/protocol v1.46.7-0.20260610022548-4fedc9bff28c/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
+github.com/livekit/protocol v1.46.7-0.20260610052126-53915ab24d75 h1:z1KJymtaqWxEN8QZlWoWiQYXabScAd/TcmbNKw62ECg=
+github.com/livekit/protocol v1.46.7-0.20260610052126-53915ab24d75/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
 github.com/livekit/psrpc v0.7.2 h1:6oZ+NODJ2pLyaT6VqDq1F4Qc/3TpDUSpyphj/P9MhQc=
 github.com/livekit/psrpc v0.7.2/go.mod h1:rAI+m2+/cb4x9RXhLRtUx5ZwdfjjXOl4zi46IjEetaw=
 github.com/livekit/server-sdk-go/v2 v2.16.7-0.20260608025623-a5da15b13baa h1:B19yilP7+JjekKMD0WejMh1Kvypdxpr5yxQZiFStRD0=

--- a/go.sum
+++ b/go.sum
@@ -357,8 +357,8 @@ github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731 h1:9x+U2HGLrSw5AT
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20260605212259-862d4a7bcb1e h1:SkgQRcG2VYEhh80Qb/zYZo8rWKJzNfJcfUQnXe6su2M=
 github.com/livekit/mediatransportutil v0.0.0-20260605212259-862d4a7bcb1e/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
-github.com/livekit/protocol v1.46.7-0.20260610173606-5e03f5ef0e6b h1:et7F8R7ldsQSYx+oViBzYm1rbr0p66e9L7CJZT1/A3M=
-github.com/livekit/protocol v1.46.7-0.20260610173606-5e03f5ef0e6b/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
+github.com/livekit/protocol v1.46.7-0.20260610175657-3ccff51ebf5b h1:F3dXIOp+D5rpXn1VwQWUm5tTV0W9Jbcf0yUrnY56sWs=
+github.com/livekit/protocol v1.46.7-0.20260610175657-3ccff51ebf5b/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
 github.com/livekit/psrpc v0.7.2 h1:6oZ+NODJ2pLyaT6VqDq1F4Qc/3TpDUSpyphj/P9MhQc=
 github.com/livekit/psrpc v0.7.2/go.mod h1:rAI+m2+/cb4x9RXhLRtUx5ZwdfjjXOl4zi46IjEetaw=
 github.com/livekit/server-sdk-go/v2 v2.16.7-0.20260608025623-a5da15b13baa h1:B19yilP7+JjekKMD0WejMh1Kvypdxpr5yxQZiFStRD0=

--- a/go.sum
+++ b/go.sum
@@ -357,10 +357,8 @@ github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731 h1:9x+U2HGLrSw5AT
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20260605212259-862d4a7bcb1e h1:SkgQRcG2VYEhh80Qb/zYZo8rWKJzNfJcfUQnXe6su2M=
 github.com/livekit/mediatransportutil v0.0.0-20260605212259-862d4a7bcb1e/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
-github.com/livekit/protocol v1.46.7-0.20260610022548-4fedc9bff28c h1:v//f0TuRu07YHame/9yvjktOV1dq7RFuFwarcepZr/o=
-github.com/livekit/protocol v1.46.7-0.20260610022548-4fedc9bff28c/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
-github.com/livekit/protocol v1.46.7-0.20260610052126-53915ab24d75 h1:z1KJymtaqWxEN8QZlWoWiQYXabScAd/TcmbNKw62ECg=
-github.com/livekit/protocol v1.46.7-0.20260610052126-53915ab24d75/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
+github.com/livekit/protocol v1.46.7-0.20260610173606-5e03f5ef0e6b h1:et7F8R7ldsQSYx+oViBzYm1rbr0p66e9L7CJZT1/A3M=
+github.com/livekit/protocol v1.46.7-0.20260610173606-5e03f5ef0e6b/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
 github.com/livekit/psrpc v0.7.2 h1:6oZ+NODJ2pLyaT6VqDq1F4Qc/3TpDUSpyphj/P9MhQc=
 github.com/livekit/psrpc v0.7.2/go.mod h1:rAI+m2+/cb4x9RXhLRtUx5ZwdfjjXOl4zi46IjEetaw=
 github.com/livekit/server-sdk-go/v2 v2.16.7-0.20260608025623-a5da15b13baa h1:B19yilP7+JjekKMD0WejMh1Kvypdxpr5yxQZiFStRD0=

--- a/go.sum
+++ b/go.sum
@@ -357,8 +357,8 @@ github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731 h1:9x+U2HGLrSw5AT
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20260605212259-862d4a7bcb1e h1:SkgQRcG2VYEhh80Qb/zYZo8rWKJzNfJcfUQnXe6su2M=
 github.com/livekit/mediatransportutil v0.0.0-20260605212259-862d4a7bcb1e/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
-github.com/livekit/protocol v1.46.7-0.20260608020211-e9abadf97706 h1:MVujVVdveJa++lNgb3ekY2+T2P8JV4RlvFqNCJyC+SM=
-github.com/livekit/protocol v1.46.7-0.20260608020211-e9abadf97706/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
+github.com/livekit/protocol v1.46.7-0.20260610022548-4fedc9bff28c h1:v//f0TuRu07YHame/9yvjktOV1dq7RFuFwarcepZr/o=
+github.com/livekit/protocol v1.46.7-0.20260610022548-4fedc9bff28c/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
 github.com/livekit/psrpc v0.7.2 h1:6oZ+NODJ2pLyaT6VqDq1F4Qc/3TpDUSpyphj/P9MhQc=
 github.com/livekit/psrpc v0.7.2/go.mod h1:rAI+m2+/cb4x9RXhLRtUx5ZwdfjjXOl4zi46IjEetaw=
 github.com/livekit/server-sdk-go/v2 v2.16.7-0.20260608025623-a5da15b13baa h1:B19yilP7+JjekKMD0WejMh1Kvypdxpr5yxQZiFStRD0=


### PR DESCRIPTION
## What

- `lk agent simulate --concurrency N`: sets the new `SimulationRun.Create.Request.concurrency` — max simulate jobs running in parallel for the run. The server clamps it to the project's concurrent-simulate quota; omitted keeps the server default (5).
- The agent subprocess is now launched with the framework's new `--simulation` flag, which disables the worker load limit so the run can saturate the agent instead of getting `WS_FULL`-throttled.

## Dependencies

- livekit/protocol#1613 (pinned to the PR branch commit — re-pin after merge)
- livekit/agents#6036 (the `--simulation` flag; older livekit-agents won't recognize it, so `thinCLIMinVersion` should be bumped to the release that includes it before this ships)
- Related: livekit/agents-private#68, livekit/cloud-api-server#1892

Stacked on #867, hence the base branch.