### PR TITLE
simulate: strip ANSI escapes from the agent log file

### DIFF
--- a/cmd/lk/simulate_subprocess.go
+++ b/cmd/lk/simulate_subprocess.go
@@ -239,7 +239,8 @@ func (ap *AgentProcess) appendLog(line string) {
 		ap.latestRoomByPx[roomNamePrefix(room)] = room
 	}
 	if ap.logFile != nil {
-		fmt.Fprintln(ap.logFile, line)
+		// the agent logs in colored format; keep the file free of ANSI escapes
+		fmt.Fprintln(ap.logFile, ansiEscapeRe.ReplaceAllString(line, ""))
 	}
 	if ap.LogStream != nil {
 		select {


### PR DESCRIPTION
The agent subprocess logs in colored format, and `lk-simulate-*.log` captured the raw lines — so the file users open after a failure was littered with ANSI escape sequences. The file write now strips them (same `ansiEscapeRe` already used for room extraction); in-memory lines and the TUI stream are unchanged.