### PR TITLE
chore: updates build to allow portaudio to be dynamically linked

### DIFF
--- a/pkg/portaudio/portaudio.go
+++ b/pkg/portaudio/portaudio.go
@@ -1,26 +1,14 @@
-// Package portaudio provides Go bindings for PortAudio, compiled from vendored source.
+// Package portaudio provides Go bindings for PortAudio.
+//
+// By default the C sources are compiled directly from the vendored pa_src
+// submodule (see portaudio_vendored*.go). Build with -tags portaudio_system to
+// link against a system libportaudio via pkg-config instead (portaudio_system.go);
+// the Homebrew formula uses this so it depends on the brew `portaudio` formula
+// rather than the vendored copy. The Go API below is identical either way.
 package portaudio
 
 /*
-#cgo CFLAGS: -I${SRCDIR}/pa_src/include -I${SRCDIR}/pa_src/src/common -DPA_LITTLE_ENDIAN -Wno-unused-parameter -Wno-deprecated-declarations
-
-#if !__has_include("pa_src/include/portaudio.h")
-#error "PortAudio submodule not found. Run: git submodule update --init --recursive"
-#else
-
-#include "pa_src/src/common/pa_allocation.c"
-#include "pa_src/src/common/pa_converters.c"
-#include "pa_src/src/common/pa_cpuload.c"
-#include "pa_src/src/common/pa_debugprint.c"
-#include "pa_src/src/common/pa_dither.c"
-#include "pa_src/src/common/pa_front.c"
-#include "pa_src/src/common/pa_process.c"
-#include "pa_src/src/common/pa_ringbuffer.c"
-#include "pa_src/src/common/pa_stream.c"
-#include "pa_src/src/common/pa_trace.c"
-
-#include "portaudio.h"
-#endif
+#include <portaudio.h>
 */
 import "C"
 

--- a/pkg/portaudio/portaudio_darwin.go
+++ b/pkg/portaudio/portaudio_darwin.go
@@ -1,3 +1,5 @@
+//go:build !portaudio_system
+
 package portaudio
 
 /*

--- a/pkg/portaudio/portaudio_linux.go
+++ b/pkg/portaudio/portaudio_linux.go
@@ -1,3 +1,5 @@
+//go:build !portaudio_system
+
 package portaudio
 
 /*

--- a/pkg/portaudio/portaudio_system.go
+++ b/pkg/portaudio/portaudio_system.go
@@ -1,0 +1,13 @@
+//go:build portaudio_system
+
+package portaudio
+
+// Link against a system libportaudio (e.g. Homebrew's `portaudio`) instead of
+// compiling the vendored sources. Selected with -tags portaudio_system. The
+// system library already bundles its host-API backends, so no per-OS backend
+// link flags are needed here. pkg-config supplies the include and link flags.
+
+/*
+#cgo pkg-config: portaudio-2.0
+*/
+import "C"

--- a/pkg/portaudio/portaudio_vendored.go
+++ b/pkg/portaudio/portaudio_vendored.go
@@ -1,0 +1,29 @@
+//go:build !portaudio_system
+
+package portaudio
+
+// Vendored PortAudio: the cross-platform core sources are compiled directly into
+// this package (a cgo unity build). The per-OS host APIs and their backend link
+// flags live in portaudio_<os>.go. Build with -tags portaudio_system to link a
+// system libportaudio instead, in which case none of these sources compile.
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/pa_src/include -I${SRCDIR}/pa_src/src/common -DPA_LITTLE_ENDIAN -Wno-unused-parameter -Wno-deprecated-declarations
+
+#if !__has_include("pa_src/include/portaudio.h")
+#error "PortAudio submodule not found. Run: git submodule update --init --recursive (or build with -tags portaudio_system to use a system libportaudio)"
+#else
+
+#include "pa_src/src/common/pa_allocation.c"
+#include "pa_src/src/common/pa_converters.c"
+#include "pa_src/src/common/pa_cpuload.c"
+#include "pa_src/src/common/pa_debugprint.c"
+#include "pa_src/src/common/pa_dither.c"
+#include "pa_src/src/common/pa_front.c"
+#include "pa_src/src/common/pa_process.c"
+#include "pa_src/src/common/pa_ringbuffer.c"
+#include "pa_src/src/common/pa_stream.c"
+#include "pa_src/src/common/pa_trace.c"
+#endif
+*/
+import "C"

--- a/pkg/portaudio/portaudio_windows.go
+++ b/pkg/portaudio/portaudio_windows.go
@@ -1,3 +1,5 @@
+//go:build !portaudio_system
+
 package portaudio
 
 /*

--- a/version.go
+++ b/version.go
@@ -15,5 +15,5 @@
 package livekitcli
 
 const (
-	Version = "2.16.5"
+	Version = "2.16.6"
 )


### PR DESCRIPTION
Homebrew maintainers did not like us vendoring `portaudio` when a formula exists for it (albeit dynamically linking the library).

For homebrew builds and whenever `portaudio_system` tag is specified, we do not use the vendored portaudio copy and instead link it dynamically. For all other builds, we continue to use the vendored copy and produce a unity build. This lets us keep other build targets portable.

Standard, vendored build:

```console
> otool -L ./bin/lk
./bin/lk:
        /System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio (compatibility version 1.0.0, current version 1.0.0)
        /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox (compatibility version 1.0.0, current version 1000.0.0)
        /System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit (compatibility version 1.0.0, current version 1.0.0)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 5026.5.4)
        /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1226.0.0)
        /usr/lib/libresolv.9.dylib (compatibility version 1.0.0, current version 1.0.0)
        /System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 61901.120.67)
        /usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 2100.43.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1356.0.0)
```

With `-tags portaudio_system`:
```console
> otool -L ./bin/lk
./bin/lk:
        /opt/homebrew/opt/portaudio/lib/libportaudio.2.dylib (compatibility version 3.0.0, current version 3.0.0)
        /System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio (compatibility version 1.0.0, current version 1.0.0)
        /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox (compatibility version 1.0.0, current version 1000.0.0)
        /System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit (compatibility version 1.0.0, current version 1.0.0)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 5026.5.4)
        /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1226.0.0)
        /usr/lib/libresolv.9.dylib (compatibility version 1.0.0, current version 1.0.0)
        /System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 61901.120.67)
        /usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 2100.43.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1356.0.0)
```