### PR TITLE
simulate: Node agent support, --view mode, and TUI/start UX fixes

### DIFF
--- a/cmd/lk/agent_run.go
+++ b/cmd/lk/agent_run.go
@@ -22,6 +22,8 @@ import (
 	"syscall"
 
 	"github.com/urfave/cli/v3"
+
+	"github.com/livekit/livekit-cli/v2/pkg/agentfs"
 )
 
 func init() {
@@ -38,7 +40,7 @@ var agentRunFlags = []cli.Flag{
 var startCommand = &cli.Command{
 	Name:      "start",
 	Usage:     "Run an agent in production mode",
-	ArgsUsage: "[entrypoint]",
+	ArgsUsage: "[entrypoint] [-- node/python-args...]",
 	Flags:     agentRunFlags,
 	Action:    runAgentStart,
 }
@@ -46,7 +48,7 @@ var startCommand = &cli.Command{
 var devCommand = &cli.Command{
 	Name:      "dev",
 	Usage:     "Run an agent in development mode with auto-reload",
-	ArgsUsage: "[entrypoint]",
+	ArgsUsage: "[entrypoint] [-- node/python-args...]",
 	Flags: append(agentRunFlags, &cli.BoolFlag{
 		Name:  "no-reload",
 		Usage: "Disable auto-reload on file changes",
@@ -57,6 +59,11 @@ var devCommand = &cli.Command{
 // resolveCredentials returns CLI args (--url, --api-key, --api-secret) for the agent subprocess.
 func resolveCredentials(cmd *cli.Command, loadOpts ...loadOption) ([]string, error) {
 	url := cmd.String("url")
+	if !cmd.IsSet("url") {
+		// Ignore the global flag's default (http://localhost:7880) so the
+		// project config can supply the URL.
+		url = ""
+	}
 	apiKey := cmd.String("api-key")
 	apiSecret := cmd.String("api-secret")
 
@@ -93,10 +100,10 @@ func resolveCredentials(cmd *cli.Command, loadOpts ...loadOption) ([]string, err
 	return args, nil
 }
 
-func buildCLIArgs(subcmd string, cmd *cli.Command, loadOpts ...loadOption) ([]string, error) {
+func buildCLIArgs(projectType agentfs.ProjectType, subcmd string, cmd *cli.Command, loadOpts ...loadOption) ([]string, error) {
 	args := []string{subcmd}
 	if logLevel := cmd.String("log-level"); logLevel != "" {
-		args = append(args, "--log-level", logLevel)
+		args = append(args, "--log-level", normalizeLogLevel(projectType, logLevel))
 	}
 	creds, err := resolveCredentials(cmd, loadOpts...)
 	if err != nil {
@@ -113,7 +120,7 @@ func runAgentStart(ctx context.Context, cmd *cli.Command) error {
 	}
 	out.Statusf("Detected %s agent (%s in %s)", projectType.Lang(), entrypoint, projectDir)
 
-	cliArgs, err := buildCLIArgs("start", cmd)
+	cliArgs, err := buildCLIArgs(projectType, "start", cmd)
 	if err != nil {
 		return err
 	}
@@ -122,6 +129,7 @@ func runAgentStart(ctx context.Context, cmd *cli.Command) error {
 		Dir:           projectDir,
 		Entrypoint:    entrypoint,
 		ProjectType:   projectType,
+		RuntimeArgs:   forwardedArgs(cmd),
 		CLIArgs:       cliArgs,
 		ForwardOutput: os.Stdout,
 	})
@@ -134,7 +142,7 @@ func runAgentStart(ctx context.Context, cmd *cli.Command) error {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
-	// Forward every signal to the agent — Python decides
+	// Forward every signal to the agent — the agent decides:
 	// first = graceful shutdown, second = force exit.
 	go func() {
 		for range sigCh {
@@ -154,19 +162,28 @@ func runAgentDev(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	cliArgs, err := buildCLIArgs("start", cmd)
+	// Python has no dedicated dev subcommand: dev mode is `start --dev`.
+	// agents-js has a `dev` subcommand that already defaults to debug logs.
+	subcmd := "dev"
+	if projectType.IsPython() {
+		subcmd = "start"
+	}
+	cliArgs, err := buildCLIArgs(projectType, subcmd, cmd)
 	if err != nil {
 		return err
 	}
-	cliArgs = append(cliArgs, "--dev")
-	if cmd.String("log-level") == "" {
-		cliArgs = append(cliArgs, "--log-level", "DEBUG")
+	if projectType.IsPython() {
+		cliArgs = append(cliArgs, "--dev")
+		if cmd.String("log-level") == "" {
+			cliArgs = append(cliArgs, "--log-level", "DEBUG")
+		}
 	}
 
 	cfg := AgentStartConfig{
 		Dir:           projectDir,
 		Entrypoint:    entrypoint,
 		ProjectType:   projectType,
+		RuntimeArgs:   forwardedArgs(cmd),
 		CLIArgs:       cliArgs,
 		ForwardOutput: os.Stdout,
 	}

--- a/cmd/lk/agent_run_test.go
+++ b/cmd/lk/agent_run_test.go
@@ -36,9 +36,12 @@ func TestAgentProcessFailSignal(t *testing.T) {
 	dir := t.TempDir()
 	script := `console.log('shutting down job task {"reason": "job crashed"}'); setTimeout(() => {}, 30000);`
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "agent.js"), []byte(script), 0o644))
-	// startAgent gates on the SDK version, so declare a satisfying dependency.
-	pkgJSON := `{"dependencies": {"@livekit/agents": "1.6.0"}}`
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(pkgJSON), 0o644))
+	// startAgent gates on the SDK version, which Node resolves from node_modules,
+	// so install a satisfying @livekit/agents stub.
+	agentsDir := filepath.Join(dir, "node_modules", "@livekit", "agents")
+	require.NoError(t, os.MkdirAll(agentsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(agentsDir, "package.json"),
+		[]byte(`{"name": "@livekit/agents", "version": "1.6.0"}`), 0o644))
 
 	ap, err := startAgent(AgentStartConfig{
 		Dir:         dir,

--- a/cmd/lk/agent_run_test.go
+++ b/cmd/lk/agent_run_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/livekit-cli/v2/pkg/agentfs"
+)
+
+func TestAgentProcessFailSignal(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not on PATH")
+	}
+
+	// An agent whose job crashes logs a marker but keeps the process alive;
+	// Failed() must fire without waiting for exit.
+	dir := t.TempDir()
+	script := `console.log('shutting down job task {"reason": "job crashed"}'); setTimeout(() => {}, 30000);`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "agent.js"), []byte(script), 0o644))
+	// startAgent gates on the SDK version, so declare a satisfying dependency.
+	pkgJSON := `{"dependencies": {"@livekit/agents": "1.6.0"}}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(pkgJSON), 0o644))
+
+	ap, err := startAgent(AgentStartConfig{
+		Dir:         dir,
+		Entrypoint:  "agent.js",
+		ProjectType: agentfs.ProjectTypeNode,
+		FailSignals: consoleCrashSignals,
+	})
+	require.NoError(t, err)
+	defer ap.Kill()
+
+	select {
+	case <-ap.Failed():
+	case <-time.After(10 * time.Second):
+		t.Fatal("Failed() did not fire on crash marker")
+	}
+}

--- a/cmd/lk/agent_utils.go
+++ b/cmd/lk/agent_utils.go
@@ -44,11 +44,8 @@ func detectProject(cmd *cli.Command) (string, agentfs.ProjectType, string, error
 		return "", "", "", noAgentError()
 	}
 
-	// TODO(node): support JS/Node agents here. DetectProjectRoot already
-	// recognizes Node projects; once the session daemon can spawn a Node
-	// agent in console mode, drop this gate and branch on projectType.
-	if !projectType.IsPython() {
-		return "", "", "", fmt.Errorf("currently only supports Python agents (detected: %s)", projectType)
+	if !projectType.IsPython() && !projectType.IsNode() {
+		return "", "", "", fmt.Errorf("only Python and Node agents are supported (detected: %s)", projectType)
 	}
 
 	if explicit != "" {

--- a/cmd/lk/agent_utils.go
+++ b/cmd/lk/agent_utils.go
@@ -18,14 +18,46 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/urfave/cli/v3"
 
 	"github.com/livekit/livekit-cli/v2/pkg/agentfs"
 )
 
+// splitForwardedArgs recovers the argument split around a "--" separator.
+// urfave/cli strips the separator and appends everything after it to the
+// parsed positional args, so the forwarded tail is recovered from the raw
+// process argv and trimmed off the positionals.
+func splitForwardedArgs(rawArgs, positional []string) (entryArgs, forwarded []string) {
+	for i, a := range rawArgs {
+		if a != "--" {
+			continue
+		}
+		forwarded = rawArgs[i+1:]
+		if len(forwarded) > len(positional) {
+			// The "--" was consumed as a flag's value, not a separator.
+			return positional, nil
+		}
+		return positional[:len(positional)-len(forwarded)], forwarded
+	}
+	return positional, nil
+}
+
+// forwardedArgs returns the args the user passed after a "--" separator,
+// forwarded to the runtime interpreter (node/python) ahead of the
+// entrypoint, e.g. `lk agent console agent.ts -- --env-file=.env`.
+func forwardedArgs(cmd *cli.Command) []string {
+	_, fwd := splitForwardedArgs(os.Args, cmd.Args().Slice())
+	return fwd
+}
+
 func detectProject(cmd *cli.Command) (string, agentfs.ProjectType, string, error) {
-	explicit := cmd.Args().First()
+	entryArgs, _ := splitForwardedArgs(os.Args, cmd.Args().Slice())
+	var explicit string
+	if len(entryArgs) > 0 {
+		explicit = entryArgs[0]
+	}
 
 	detectFrom := "."
 	if explicit != "" {
@@ -64,6 +96,16 @@ func detectProject(cmd *cli.Command) (string, agentfs.ProjectType, string, error
 	return projectDir, projectType, entrypoint, nil
 }
 
+// consoleCrashSignals are output markers meaning the console job died even
+// though the worker process may stay alive: the Python SDK keeps the worker
+// running after the job task crashes (logging `"reason": "job crashed"`), and
+// agents-js logs FATAL `console mode failed:` before exiting. Without these,
+// a pre-connect crash leaves the user waiting out the full connect timeout.
+var consoleCrashSignals = []string{
+	`"job crashed"`,
+	"console mode failed:",
+}
+
 // buildConsoleArgs builds the agent subprocess argv for console mode, shared by
 // `lk agent console` and the `lk agent daemon` daemon.
 func buildConsoleArgs(addr string, record bool) []string {
@@ -72,4 +114,13 @@ func buildConsoleArgs(addr string, record bool) []string {
 		args = append(args, "--record")
 	}
 	return args
+}
+
+// normalizeLogLevel adapts the log level to the agent runtime's convention:
+// agents-js accepts only lowercase levels, Python expects uppercase.
+func normalizeLogLevel(projectType agentfs.ProjectType, level string) string {
+	if projectType.IsNode() {
+		return strings.ToLower(level)
+	}
+	return strings.ToUpper(level)
 }

--- a/cmd/lk/agent_watcher.go
+++ b/cmd/lk/agent_watcher.go
@@ -80,14 +80,18 @@ func newAgentWatcher(config AgentStartConfig) (*agentWatcher, error) {
 		return nil, fmt.Errorf("failed to setup file watcher: %w", err)
 	}
 
-	rs, err := newReloadServer()
-	if err != nil {
-		w.Close()
-		return nil, err
+	// The reload protocol (capture running jobs from the old process, restore
+	// them in the new one) is Python-only; Node reloads are a plain kill+respawn.
+	var rs *reloadServer
+	if config.ProjectType.IsPython() {
+		rs, err = newReloadServer()
+		if err != nil {
+			w.Close()
+			return nil, err
+		}
+		// Append --reload-addr to CLI args so the Python process connects back
+		config.CLIArgs = append(config.CLIArgs, "--reload-addr", rs.addr())
 	}
-
-	// Append --dev and --reload-addr to CLI args so the Python process connects back
-	config.CLIArgs = append(config.CLIArgs, "--dev", "--reload-addr", rs.addr())
 
 	return &agentWatcher{
 		config:    config,
@@ -107,15 +111,17 @@ func (aw *agentWatcher) start() error {
 	aw.agent = agent
 
 	// Accept connection from new Python process in background
-	go func() {
-		conn, err := aw.reloadSrv.listener.Accept()
-		if err != nil {
-			return
-		}
-		aw.conn = conn
-		// Serve the initial restore request (will be empty on first start)
-		go aw.reloadSrv.serveNewProcess(conn)
-	}()
+	if aw.reloadSrv != nil {
+		go func() {
+			conn, err := aw.reloadSrv.listener.Accept()
+			if err != nil {
+				return
+			}
+			aw.conn = conn
+			// Serve the initial restore request (will be empty on first start)
+			go aw.reloadSrv.serveNewProcess(conn)
+		}()
+	}
 
 	return nil
 }
@@ -143,14 +149,16 @@ func (aw *agentWatcher) restart() error {
 	aw.agent = agent
 
 	// 4. Accept new connection and serve restored jobs
-	go func() {
-		conn, err := aw.reloadSrv.listener.Accept()
-		if err != nil {
-			return
-		}
-		aw.conn = conn
-		go aw.reloadSrv.serveNewProcess(conn)
-	}()
+	if aw.reloadSrv != nil {
+		go func() {
+			conn, err := aw.reloadSrv.listener.Accept()
+			if err != nil {
+				return
+			}
+			aw.conn = conn
+			go aw.reloadSrv.serveNewProcess(conn)
+		}()
+	}
 
 	return nil
 }
@@ -176,7 +184,9 @@ func (aw *agentWatcher) Run(done <-chan struct{}) error {
 		if aw.conn != nil {
 			aw.conn.Close()
 		}
-		aw.reloadSrv.close()
+		if aw.reloadSrv != nil {
+			aw.reloadSrv.close()
+		}
 		aw.watcher.Close()
 	}()
 

--- a/cmd/lk/console.go
+++ b/cmd/lk/console.go
@@ -41,7 +41,7 @@ func init() {
 var consoleCommand = &cli.Command{
 	Name:      "console",
 	Usage:     "Voice chat with an agent via mic/speakers",
-	ArgsUsage: "[entrypoint]",
+	ArgsUsage: "[entrypoint] [-- node/python-args...]",
 	Category:  "Core",
 	Flags: []cli.Flag{
 		&cli.IntFlag{
@@ -141,7 +141,9 @@ func runConsole(ctx context.Context, cmd *cli.Command) error {
 		Dir:         projectDir,
 		Entrypoint:  entrypoint,
 		ProjectType: projectType,
+		RuntimeArgs: forwardedArgs(cmd),
 		CLIArgs:     buildConsoleArgs(actualAddr, cmd.Bool("record")),
+		FailSignals: consoleCrashSignals,
 	})
 	if err != nil {
 		stopSpinner()
@@ -171,9 +173,17 @@ func runConsole(ctx context.Context, cmd *cli.Command) error {
 			return fmt.Errorf("agent connection: %w", res.err)
 		}
 		conn = res.conn
-	case <-agentProc.Done():
+	case err := <-agentProc.Done():
 		stopSpinner()
+		if err != nil {
+			return fmt.Errorf("the agent exited before connecting: %w\n\n%s", err, agentExitDetail(agentProc))
+		}
 		return fmt.Errorf("the agent exited before connecting.\n\n%s", agentExitDetail(agentProc))
+	case <-agentProc.Failed():
+		stopSpinner()
+		// The crash marker arrives mid-traceback; give trailing output a moment.
+		time.Sleep(500 * time.Millisecond)
+		return fmt.Errorf("the agent job crashed before connecting.\n\n%s", agentExitDetail(agentProc))
 	case <-time.After(60 * time.Second):
 		stopSpinner()
 		return fmt.Errorf("timed out waiting for the agent to connect.\n\n%s", agentExitDetail(agentProc))

--- a/cmd/lk/node_resolve_version.js
+++ b/cmd/lk/node_resolve_version.js
@@ -1,0 +1,20 @@
+// Reports the installed @livekit/agents version using Node's own module
+// resolution paths, so pnpm/workspace symlinks and hoisting resolve exactly as
+// they will at runtime. Reads package.json directly, so it works even before
+// the package is built. Prints the version to stdout, or exits non-zero if the
+// package can't be found.
+const { createRequire } = require('module');
+const path = require('path');
+const fs = require('fs');
+
+try {
+  const req = createRequire(path.join(process.cwd(), 'noop.js'));
+  for (const base of req.resolve.paths('@livekit/agents') || []) {
+    const pkgPath = path.join(base, '@livekit/agents', 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      process.stdout.write(JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version || '');
+      process.exit(0);
+    }
+  }
+} catch (e) {}
+process.exit(1);

--- a/cmd/lk/proc_unix.go
+++ b/cmd/lk/proc_unix.go
@@ -32,7 +32,7 @@ func (ap *AgentProcess) sendKill() {
 }
 
 // sendShutdown sends SIGINT to the main process only (not the group),
-// letting Python manage its own child cleanup.
+// letting the agent manage its own child cleanup.
 func (ap *AgentProcess) sendShutdown() {
 	if ap.cmd.Process != nil {
 		ap.cmd.Process.Signal(syscall.SIGINT)

--- a/cmd/lk/session.go
+++ b/cmd/lk/session.go
@@ -71,7 +71,7 @@ var agentDaemonCommand = &cli.Command{
 		{
 			Name:      "start",
 			Usage:     "Start a detached agent session daemon",
-			ArgsUsage: "[entrypoint]",
+			ArgsUsage: "[entrypoint] [-- node/python-args...]",
 			Flags:     []cli.Flag{sessionPortFlag},
 			Action:    runSessionStart,
 		},

--- a/cmd/lk/session_daemon.go
+++ b/cmd/lk/session_daemon.go
@@ -47,11 +47,14 @@ func runSessionDaemon() {
 	}
 	defer server.Close()
 
+	// startAgent branches on ProjectType, so Node entrypoints run as
+	// `node <entry> console ...` without any extra wiring here.
 	agentProc, err := startAgent(AgentStartConfig{
 		Dir:         os.Getenv(envSessionDir),
 		Entrypoint:  os.Getenv(envSessionEntry),
 		ProjectType: agentfs.ProjectType(os.Getenv(envSessionPType)),
 		CLIArgs:     buildConsoleArgs(server.Addr().String(), false),
+		FailSignals: consoleCrashSignals,
 	})
 	if err != nil {
 		signalReady(ready, "error: failed to start agent: "+err.Error())
@@ -81,6 +84,10 @@ func runSessionDaemon() {
 			msg += ": " + waitErr.Error()
 		}
 		signalReady(ready, msg)
+		agentProc.Kill()
+		os.Exit(1)
+	case <-agentProc.Failed():
+		signalReady(ready, "error: agent job crashed before connecting; logs: "+agentProc.LogPath)
 		agentProc.Kill()
 		os.Exit(1)
 	case <-time.After(60 * time.Second):

--- a/cmd/lk/session_daemon.go
+++ b/cmd/lk/session_daemon.go
@@ -47,8 +47,6 @@ func runSessionDaemon() {
 	}
 	defer server.Close()
 
-	// TODO(node): detect a node/JS agent project and build the equivalent
-	// `node <entry> console --connect-addr <addr>` argv.
 	agentProc, err := startAgent(AgentStartConfig{
 		Dir:         os.Getenv(envSessionDir),
 		Entrypoint:  os.Getenv(envSessionEntry),

--- a/cmd/lk/simulate.go
+++ b/cmd/lk/simulate.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -87,6 +88,10 @@ var simulateCommand = &cli.Command{
 			Name:    "yes",
 			Aliases: []string{"y"},
 			Usage:   "Skip the source-upload confirmation prompt (required for non-interactive runs that generate from source)",
+		},
+		&cli.StringFlag{
+			Name:  "view",
+			Usage: "Open a pre-existing simulation",
 		},
 	},
 }
@@ -168,6 +173,7 @@ type simulateConfig struct {
 	entrypoint     string
 	scenarioGroup  *livekit.ScenarioGroup
 	scenariosPath  string // path to the --scenarios file (empty when generating from source)
+	viewModeRunID  string // non-empty when --view opens a pre-existing run
 }
 
 type simulateMode int
@@ -175,6 +181,7 @@ type simulateMode int
 const (
 	modeScenarios simulateMode = iota
 	modeGenerateFromSource
+	modeView
 )
 
 func loadScenarioGroup(path string) (*livekit.ScenarioGroup, error) {
@@ -217,22 +224,54 @@ func generateAgentName() string {
 	return "simulation-" + string(b)
 }
 
+type PackageJSON struct {
+	Scripts map[string]string `json:"scripts"`
+}
+
+// buildTaskExists reports whether package.json defines a "build" script. Such a
+// task usually means the entrypoint path is nontrivial (todo: check dist/main.js).
+func buildTaskExists(projectDir string) (bool, error) {
+	data, err := os.ReadFile(filepath.Join(projectDir, "package.json"))
+	if err != nil {
+		return false, err
+	}
+
+	var pkg PackageJSON
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return false, err
+	}
+
+	_, ok := pkg.Scripts["build"]
+	return ok, nil
+}
+
 func runSimulate(ctx context.Context, cmd *cli.Command) error {
 	pc := simulateProjectConfig
 
 	numSimulations := int32(cmd.Int("num-simulations"))
 	concurrency := int32(cmd.Int("concurrency"))
+	runID := cmd.String("view")
 	agentName := generateAgentName()
 
 	projectDir, projectType, err := agentfs.DetectProjectRoot(".")
 	if err != nil {
 		return err
 	}
-	if !projectType.IsPython() {
-		return fmt.Errorf("simulate currently only supports Python agents (detected: %s)", projectType)
+
+	entrypointArg := cmd.Args().First()
+
+	// check if a script called "build" exists in the package.json, if so, refuse to discover the
+	// entrypoint: build tasks usually mean the entrypoint path is nontrivial (e.g. dist/main.js)
+	if projectType.IsNode() && entrypointArg == "" {
+		buildTaskDoesExist, err := buildTaskExists(projectDir)
+		if err != nil {
+			return err
+		} else if buildTaskDoesExist {
+			return fmt.Errorf("you currently have a build task in your package.json, but no entrypoint was explicitly given; so you must add an entrypoint to the simulate cli")
+		}
 	}
 
-	entrypoint, err := findEntrypoint(projectDir, cmd.Args().First(), projectType)
+	entrypoint, err := findEntrypoint(projectDir, entrypointArg, projectType)
 	if err != nil {
 		return err
 	}
@@ -250,9 +289,12 @@ func runSimulate(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	var mode simulateMode
-	if scenarioGroup != nil && len(scenarioGroup.Scenarios) > 0 {
+	switch {
+	case runID != "":
+		mode = modeView
+	case scenarioGroup != nil && len(scenarioGroup.Scenarios) > 0:
 		mode = modeScenarios
-	} else {
+	default:
 		mode = modeGenerateFromSource
 	}
 
@@ -283,6 +325,7 @@ func runSimulate(ctx context.Context, cmd *cli.Command) error {
 		entrypoint:     entrypoint,
 		scenarioGroup:  scenarioGroup,
 		scenariosPath:  scenariosPath,
+		viewModeRunID:  runID,
 	}
 
 	if !isInteractive() {
@@ -380,20 +423,26 @@ func (l *agentLauncher) ForceStop() {
 }
 
 func startSimulationAgent(c *simulateConfig, forwardOutput io.Writer) (*AgentProcess, error) {
+	args := []string{
+		"start",
+		"--url", c.pc.URL,
+		"--api-key", c.pc.APIKey,
+		"--api-secret", c.pc.APISecret,
+		"--log-level", normalizeLogLevel(c.projectType, "DEBUG"),
+		// disable the worker load limit so the run can saturate the agent
+		"--simulation",
+	}
+
+	// --log-format is a Python-only flag; the Node CLI doesn't accept it.
+	if c.projectType.IsPython() {
+		args = append(args, "--log-format", "colored")
+	}
+
 	return startAgent(AgentStartConfig{
 		Dir:         c.projectDir,
 		Entrypoint:  c.entrypoint,
 		ProjectType: c.projectType,
-		CLIArgs: []string{
-			"start",
-			"--url", c.pc.URL,
-			"--api-key", c.pc.APIKey,
-			"--api-secret", c.pc.APISecret,
-			"--log-level", "DEBUG",
-			"--log-format", "colored",
-			// disable the worker load limit so the run can saturate the agent
-			"--simulation",
-		},
+		CLIArgs:     args,
 		Env: []string{
 			// register under the dispatch name regardless of any agent_name
 			// hardcoded in the user's code

--- a/cmd/lk/simulate_subprocess.go
+++ b/cmd/lk/simulate_subprocess.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -23,6 +24,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -30,10 +32,11 @@ import (
 	"github.com/livekit/livekit-cli/v2/pkg/agentfs"
 )
 
-// AgentProcess manages a Python agent subprocess.
+// AgentProcess manages an agent subprocess.
 type AgentProcess struct {
 	cmd            *exec.Cmd
 	readyCh        chan struct{}
+	failCh         chan struct{} // closed when output matches a FailSignal
 	doneCh         chan error
 	exitCh         chan struct{} // closed when process exits, safe to read multiple times
 	shutdownCalled bool          // true after Shutdown() sends SIGINT
@@ -97,6 +100,55 @@ func isTypeScriptEntry(entry string) bool {
 	}
 }
 
+var nodeVersionRe = regexp.MustCompile(`v(\d+)\.(\d+)`)
+
+// checkTypeStrippingSupport verifies the Node binary can run TypeScript
+// directly (--experimental-strip-types requires Node >= 22.6). The probe
+// runs in the project dir so version-manager shims resolve the same Node
+// the spawn will use. Probing failures are ignored — the spawn itself will
+// surface any real error.
+func checkTypeStrippingSupport(dir, nodeBin string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, nodeBin, "--version")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+	version := strings.TrimSpace(string(out))
+	m := nodeVersionRe.FindStringSubmatch(version)
+	if m == nil {
+		return nil
+	}
+	major, _ := strconv.Atoi(m[1])
+	minor, _ := strconv.Atoi(m[2])
+	if major < 22 || (major == 22 && minor < 6) {
+		return fmt.Errorf("running a TypeScript entrypoint directly requires Node >= 22.6 (found %s); upgrade Node or point at built JS output", version)
+	}
+	return nil
+}
+
+// defaultEntrypoints returns candidate entrypoint paths (relative to the
+// project root or working directory) probed for a project type, in priority
+// order. Forward slashes are valid on all platforms.
+func defaultEntrypoints(projectType agentfs.ProjectType) []string {
+	if projectType.IsNode() {
+		return []string{"agent.ts", "agent.js"}
+	}
+	return []string{"agent.py"}
+}
+
+// fallbackEntrypoints are probed at the project root only after cwd-relative
+// candidates, so a root src/ layout doesn't shadow an agent next to the
+// user's working directory.
+func fallbackEntrypoints(projectType agentfs.ProjectType) []string {
+	if projectType.IsNode() {
+		return []string{"src/agent.ts", "src/agent.js"}
+	}
+	return []string{"src/agent.py"}
+}
+
 // findEntrypoint resolves the agent entrypoint file.
 func findEntrypoint(dir, explicit string, projectType agentfs.ProjectType) (string, error) {
 	if explicit != "" {
@@ -109,36 +161,49 @@ func findEntrypoint(dir, explicit string, projectType agentfs.ProjectType) (stri
 		}
 		return explicit, nil
 	}
-	def := projectType.DefaultEntrypoint()
-	if def == "" {
-		def = "agent.py"
-	}
+	rootCandidates := defaultEntrypoints(projectType)
+	srcCandidates := fallbackEntrypoints(projectType)
 
 	// Check project root first
-	checked := []string{filepath.Join(dir, def)}
-	if _, err := os.Stat(checked[0]); err == nil {
-		return def, nil
+	var checked []string
+	probe := func(rel string) bool {
+		abs := filepath.Join(dir, rel)
+		checked = append(checked, abs)
+		_, err := os.Stat(abs)
+		return err == nil
 	}
-
-	// Fall back to cwd-relative path (e.g. running from examples/drive-thru/)
-	cwd, _ := os.Getwd()
-	if rel, err := filepath.Rel(dir, cwd); err == nil && rel != "." {
-		candidate := filepath.Join(rel, def)
-		absCandidate := filepath.Join(dir, candidate)
-		checked = append(checked, absCandidate)
-		if _, err := os.Stat(absCandidate); err == nil {
-			return candidate, nil
+	for _, def := range rootCandidates {
+		if probe(def) {
+			return def, nil
 		}
 	}
 
-	var msg strings.Builder
-	msg.WriteString("no agent entrypoint found, checked:\n")
-	for _, p := range checked {
-		fmt.Fprintf(&msg, "  - %s\n", p)
+	// Then cwd-relative paths (e.g. running from examples/drive-thru/)
+	cwd, _ := os.Getwd()
+	if rel, err := filepath.Rel(dir, cwd); err == nil && rel != "." {
+		for _, def := range append(append([]string{}, rootCandidates...), srcCandidates...) {
+			candidate := filepath.Join(rel, def)
+			if probe(candidate) {
+				return candidate, nil
+			}
+		}
 	}
-	msg.WriteString("\nMake sure you are running this command from a directory containing a LiveKit agent.\n")
-	msg.WriteString("Specify the entrypoint file as a positional argument, e.g.: lk agent simulate agent.py")
-	return "", fmt.Errorf("%s", msg.String())
+
+	// Finally the project root's src/ layout
+	for _, def := range srcCandidates {
+		if probe(def) {
+			return def, nil
+		}
+	}
+
+	example := rootCandidates[0]
+	msg := "no agent entrypoint found, checked:\n"
+	for _, p := range checked {
+		msg += fmt.Sprintf("  - %s\n", p)
+	}
+	msg += "\nMake sure you are running this command from a directory containing a LiveKit agent.\n"
+	msg += fmt.Sprintf("Specify the entrypoint file as a positional argument, e.g.: lk agent dev %s", example)
+	return "", fmt.Errorf("%s", msg)
 }
 
 // AgentStartConfig configures how to launch an agent subprocess.
@@ -146,9 +211,11 @@ type AgentStartConfig struct {
 	Dir           string
 	Entrypoint    string
 	ProjectType   agentfs.ProjectType
+	RuntimeArgs   []string  // interpreter (node/python) args placed before the entrypoint, e.g. ["--env-file=.env"]
 	CLIArgs       []string  // subcommand first, then flags: ["start", "--url", "..."] or ["console", "--connect-addr", addr]
 	Env           []string  // e.g. ["LIVEKIT_AGENT_NAME_OVERRIDE=x"] or nil
 	ReadySignal   string    // substring to scan for in output (e.g. "registered worker"), empty to skip
+	FailSignals   []string  // output substrings meaning the agent has fatally failed even if the process is still alive
 	ForwardOutput io.Writer // if set, forward each output line to this writer
 }
 
@@ -188,20 +255,24 @@ func lastNonEmptyLines(lines []string, n int) []string {
 
 // buildAgentCommand resolves the interpreter and argv for an agent subprocess,
 // branching on project type. Python uses the thin CLI:
-// `<python> -m livekit.agents SUBCOMMAND ENTRYPOINT FLAGS` (uv prefixes
-// `run python`). Node runs the entrypoint directly:
-// `node [--experimental-strip-types] ENTRYPOINT SUBCOMMAND FLAGS`, where the
-// type-stripping flag lets a `.ts` entrypoint run without a build.
+// `<python> <runtime-args> -m livekit.agents SUBCOMMAND ENTRYPOINT FLAGS`
+// (uv prefixes `run python`). Node runs the entrypoint directly:
+// `node [--experimental-strip-types] <runtime-args> ENTRYPOINT SUBCOMMAND FLAGS`,
+// where the type-stripping flag lets a `.ts` entrypoint run without a build.
 func buildAgentCommand(cfg AgentStartConfig) (string, []string, error) {
 	if cfg.ProjectType.IsNode() {
 		nodeBin, err := findNodeBinary()
 		if err != nil {
 			return "", nil, err
 		}
-		args := make([]string, 0, len(cfg.CLIArgs)+2)
+		args := make([]string, 0, len(cfg.RuntimeArgs)+len(cfg.CLIArgs)+2)
 		if isTypeScriptEntry(cfg.Entrypoint) {
+			if err := checkTypeStrippingSupport(cfg.Dir, nodeBin); err != nil {
+				return "", nil, err
+			}
 			args = append(args, "--experimental-strip-types")
 		}
+		args = append(args, cfg.RuntimeArgs...)
 		args = append(args, cfg.Entrypoint)
 		args = append(args, cfg.CLIArgs...)
 		return nodeBin, args, nil
@@ -213,7 +284,10 @@ func buildAgentCommand(cfg AgentStartConfig) (string, []string, error) {
 	}
 	// python -m livekit.agents SUBCOMMAND ENTRYPOINT FLAGS: the framework
 	// discovers the AgentServer from the entrypoint and drives the thin CLI.
-	args := append(prefixArgs, "-m", "livekit.agents")
+	args := make([]string, 0, len(prefixArgs)+len(cfg.RuntimeArgs)+len(cfg.CLIArgs)+4)
+	args = append(args, prefixArgs...)
+	args = append(args, cfg.RuntimeArgs...)
+	args = append(args, "-m", "livekit.agents")
 	if len(cfg.CLIArgs) > 0 {
 		args = append(args, cfg.CLIArgs[0]) // subcommand: start | console
 		args = append(args, cfg.Entrypoint) // entrypoint positional (server discovery)
@@ -262,6 +336,7 @@ func startAgent(cfg AgentStartConfig) (*AgentProcess, error) {
 	ap := &AgentProcess{
 		cmd:            cmd,
 		readyCh:        make(chan struct{}),
+		failCh:         make(chan struct{}),
 		doneCh:         make(chan error, 1),
 		exitCh:         make(chan struct{}),
 		roomLogs:       make(map[string][]string),
@@ -278,6 +353,7 @@ func startAgent(cfg AgentStartConfig) (*AgentProcess, error) {
 
 	// Capture output from both stdout and stderr
 	readyOnce := sync.Once{}
+	failOnce := sync.Once{}
 	scanOutput := func(r io.Reader) {
 		scanner := bufio.NewScanner(r)
 		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -291,6 +367,12 @@ func startAgent(cfg AgentStartConfig) (*AgentProcess, error) {
 			}
 			if cfg.ReadySignal != "" && strings.Contains(line, cfg.ReadySignal) {
 				readyOnce.Do(func() { close(ap.readyCh) })
+			}
+			for _, sig := range cfg.FailSignals {
+				if strings.Contains(line, sig) {
+					failOnce.Do(func() { close(ap.failCh) })
+					break
+				}
 			}
 		}
 	}
@@ -344,6 +426,12 @@ func (ap *AgentProcess) Ready() <-chan struct{} {
 // Done returns a channel that receives the process exit error.
 func (ap *AgentProcess) Done() <-chan error {
 	return ap.doneCh
+}
+
+// Failed returns a channel that is closed when the agent's output matched one
+// of the configured FailSignals — a fatal failure even if the process is alive.
+func (ap *AgentProcess) Failed() <-chan struct{} {
+	return ap.failCh
 }
 
 // RecentLogs returns the last n log lines from the subprocess. If n <= 0, returns all lines.

--- a/cmd/lk/simulate_subprocess.go
+++ b/cmd/lk/simulate_subprocess.go
@@ -134,7 +134,7 @@ func checkTypeStrippingSupport(dir, nodeBin string) error {
 // order. Forward slashes are valid on all platforms.
 func defaultEntrypoints(projectType agentfs.ProjectType) []string {
 	if projectType.IsNode() {
-		return []string{"agent.ts", "agent.js"}
+		return []string{"main.ts", "src/main.js"}
 	}
 	return []string{"agent.py"}
 }
@@ -144,7 +144,7 @@ func defaultEntrypoints(projectType agentfs.ProjectType) []string {
 // user's working directory.
 func fallbackEntrypoints(projectType agentfs.ProjectType) []string {
 	if projectType.IsNode() {
-		return []string{"src/agent.ts", "src/agent.js"}
+		return []string{"src/main.ts", "src/main.js"}
 	}
 	return []string{"src/agent.py"}
 }
@@ -222,36 +222,6 @@ type AgentStartConfig struct {
 // thinCLIMinVersion is the first livekit-agents release that exposes the
 // start/dev/console/simulate subcommands under `python -m livekit.agents`.
 const thinCLIMinVersion = "1.6.0"
-
-// agentExitDetail surfaces the agent's own output and the log path when the
-// worker exits early or never registers.
-func agentExitDetail(ap *AgentProcess) string {
-	var b strings.Builder
-	if tail := lastNonEmptyLines(ap.RecentLogs(0), 12); len(tail) > 0 {
-		for i, l := range tail {
-			tail[i] = ansiEscapeRe.ReplaceAllString(l, "")
-		}
-		b.WriteString("Agent output:\n  " + strings.Join(tail, "\n  "))
-	}
-	if ap.LogPath != "" {
-		if b.Len() > 0 {
-			b.WriteString("\n\n")
-		}
-		b.WriteString("Full log: " + ap.LogPath)
-	}
-	return b.String()
-}
-
-// lastNonEmptyLines returns up to n trailing non-blank lines, in order.
-func lastNonEmptyLines(lines []string, n int) []string {
-	var out []string
-	for i := len(lines) - 1; i >= 0 && len(out) < n; i-- {
-		if strings.TrimSpace(lines[i]) != "" {
-			out = append([]string{lines[i]}, out...)
-		}
-	}
-	return out
-}
 
 // buildAgentCommand resolves the interpreter and argv for an agent subprocess,
 // branching on project type. Python uses the thin CLI:
@@ -502,6 +472,41 @@ func (ap *AgentProcess) RecentRoomLogsByPrefix(n int, roomName string) []string 
 }
 
 var ansiEscapeRe = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// agentExitDetail surfaces the agent's own output and the log path when the
+// worker exits early or never registers.
+func agentExitDetail(ap *AgentProcess) string {
+	logs := ap.RecentLogs(0)
+
+	var b strings.Builder
+
+	if len(logs) == 0 {
+		b.WriteString("Agent exited with no output.")
+	} else if tail := lastNonEmptyLines(logs, 12); len(tail) > 0 {
+		for i, l := range tail {
+			tail[i] = ansiEscapeRe.ReplaceAllString(l, "")
+		}
+		b.WriteString("Agent output:\n  " + strings.Join(tail, "\n  "))
+	}
+
+	if ap.LogPath != "" {
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString("Full log: " + ap.LogPath)
+	}
+	return b.String()
+}
+
+func lastNonEmptyLines(lines []string, n int) []string {
+	var out []string
+	for i := len(lines) - 1; i >= 0 && len(out) < n; i-- {
+		if strings.TrimSpace(lines[i]) != "" {
+			out = append([]string{lines[i]}, out...)
+		}
+	}
+	return out
+}
 
 func extractLogRoom(line string) string {
 	idx := strings.LastIndex(line, "{")

--- a/cmd/lk/simulate_subprocess.go
+++ b/cmd/lk/simulate_subprocess.go
@@ -77,6 +77,26 @@ func findPythonBinary(dir string, projectType agentfs.ProjectType) (string, []st
 	return pythonPath, nil, nil
 }
 
+// findNodeBinary locates the Node binary used to run a JS/TS agent.
+func findNodeBinary() (string, error) {
+	nodePath, err := exec.LookPath("node")
+	if err != nil {
+		return "", fmt.Errorf("could not find Node binary; ensure node is on PATH")
+	}
+	return nodePath, nil
+}
+
+// isTypeScriptEntry reports whether the entrypoint is TypeScript source that
+// needs Node's type-stripping loader to run directly (no build step).
+func isTypeScriptEntry(entry string) bool {
+	switch strings.ToLower(filepath.Ext(entry)) {
+	case ".ts", ".mts", ".cts":
+		return true
+	default:
+		return false
+	}
+}
+
 // findEntrypoint resolves the agent entrypoint file.
 func findEntrypoint(dir, explicit string, projectType agentfs.ProjectType) (string, error) {
 	if explicit != "" {
@@ -166,21 +186,31 @@ func lastNonEmptyLines(lines []string, n int) []string {
 	return out
 }
 
-// startAgent launches a Python agent subprocess and monitors its output.
-func startAgent(cfg AgentStartConfig) (*AgentProcess, error) {
+// buildAgentCommand resolves the interpreter and argv for an agent subprocess,
+// branching on project type. Python uses the thin CLI:
+// `<python> -m livekit.agents SUBCOMMAND ENTRYPOINT FLAGS` (uv prefixes
+// `run python`). Node runs the entrypoint directly:
+// `node [--experimental-strip-types] ENTRYPOINT SUBCOMMAND FLAGS`, where the
+// type-stripping flag lets a `.ts` entrypoint run without a build.
+func buildAgentCommand(cfg AgentStartConfig) (string, []string, error) {
+	if cfg.ProjectType.IsNode() {
+		nodeBin, err := findNodeBinary()
+		if err != nil {
+			return "", nil, err
+		}
+		args := make([]string, 0, len(cfg.CLIArgs)+2)
+		if isTypeScriptEntry(cfg.Entrypoint) {
+			args = append(args, "--experimental-strip-types")
+		}
+		args = append(args, cfg.Entrypoint)
+		args = append(args, cfg.CLIArgs...)
+		return nodeBin, args, nil
+	}
+
 	pythonBin, prefixArgs, err := findPythonBinary(cfg.Dir, cfg.ProjectType)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
-
-	// fail fast when livekit-agents is older than the thin-CLI baseline
-	if err := agentfs.CheckSDKVersion(cfg.Dir, cfg.ProjectType, map[string]string{
-		"python-min-sdk-version": thinCLIMinVersion,
-		"node-min-sdk-version":   thinCLIMinVersion,
-	}); err != nil {
-		return nil, err
-	}
-
 	// python -m livekit.agents SUBCOMMAND ENTRYPOINT FLAGS: the framework
 	// discovers the AgentServer from the entrypoint and drives the thin CLI.
 	args := append(prefixArgs, "-m", "livekit.agents")
@@ -191,7 +221,24 @@ func startAgent(cfg AgentStartConfig) (*AgentProcess, error) {
 	} else {
 		args = append(args, cfg.Entrypoint)
 	}
-	cmd := exec.Command(pythonBin, args...)
+	return pythonBin, args, nil
+}
+
+// startAgent launches a Python or Node agent subprocess and monitors its output.
+func startAgent(cfg AgentStartConfig) (*AgentProcess, error) {
+	// fail fast when livekit-agents is older than the thin-CLI baseline
+	if err := agentfs.CheckSDKVersion(cfg.Dir, cfg.ProjectType, map[string]string{
+		"python-min-sdk-version": thinCLIMinVersion,
+		"node-min-sdk-version":   thinCLIMinVersion,
+	}); err != nil {
+		return nil, err
+	}
+
+	bin, args, err := buildAgentCommand(cfg)
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command(bin, args...)
 	setProcAttr(cmd)
 	cmd.Dir = cfg.Dir
 	if len(cfg.Env) > 0 {

--- a/cmd/lk/simulate_subprocess.go
+++ b/cmd/lk/simulate_subprocess.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bufio"
 	"context"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -125,6 +126,56 @@ func checkTypeStrippingSupport(dir, nodeBin string) error {
 	minor, _ := strconv.Atoi(m[2])
 	if major < 22 || (major == 22 && minor < 6) {
 		return fmt.Errorf("running a TypeScript entrypoint directly requires Node >= 22.6 (found %s); upgrade Node or point at built JS output", version)
+	}
+	return nil
+}
+
+// nodeAgentMinVersion is the minimum @livekit/agents (agents-js) release the
+// CLI supports. Unlike the Python thin CLI (gated on thinCLIMinVersion), the
+// Node entrypoint exposes the start/console/simulate subcommands directly, so
+// the baseline differs. Local placeholder — the deploy path sources the
+// equivalent floor from server client settings.
+const nodeAgentMinVersion = "1.0.0"
+
+// nodeResolveVersionScript asks Node to report the installed @livekit/agents
+// version using its own module resolution paths (so pnpm/workspace symlinks
+// and hoisting resolve exactly as they will at runtime). See the source file
+// for details.
+//
+//go:embed node_resolve_version.js
+var nodeResolveVersionScript string
+
+// resolveNodeAgentVersion returns the installed @livekit/agents version as Node
+// resolves it from fromDir, or "" if it can't be determined.
+func resolveNodeAgentVersion(nodeBin, fromDir string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, nodeBin, "-e", nodeResolveVersionScript)
+	cmd.Dir = fromDir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// checkNodeSDKVersion gates a Node agent on nodeAgentMinVersion, resolving the
+// installed @livekit/agents from the entrypoint's directory so monorepo and
+// workspace layouts (where the dep is a workspace:* symlink, not a versioned
+// entry in the root package.json) report the version that will actually run.
+func checkNodeSDKVersion(cfg AgentStartConfig) error {
+	nodeBin, err := findNodeBinary()
+	if err != nil {
+		return err
+	}
+	fromDir := filepath.Dir(filepath.Join(cfg.Dir, cfg.Entrypoint))
+	version := resolveNodeAgentVersion(nodeBin, fromDir)
+	if version == "" {
+		return fmt.Errorf("@livekit/agents not found; install dependencies and make sure this is a LiveKit agent project")
+	}
+	// An unparseable version (e.g. a local "0.0.0-dev" tag) shouldn't block a run.
+	if ok, err := agentfs.IsVersionSatisfied(version, nodeAgentMinVersion); err == nil && !ok {
+		return fmt.Errorf("@livekit/agents version %s is too old, please upgrade to %s or newer", version, nodeAgentMinVersion)
 	}
 	return nil
 }
@@ -270,8 +321,14 @@ func buildAgentCommand(cfg AgentStartConfig) (string, []string, error) {
 
 // startAgent launches a Python or Node agent subprocess and monitors its output.
 func startAgent(cfg AgentStartConfig) (*AgentProcess, error) {
-	// fail fast when livekit-agents is older than the thin-CLI baseline
-	if err := agentfs.CheckSDKVersion(cfg.Dir, cfg.ProjectType, map[string]string{
+	// fail fast when the agent SDK is older than the baseline the CLI supports.
+	// Node resolves the installed package via the runtime so workspace/monorepo
+	// layouts work; Python parses project files against the thin-CLI baseline.
+	if cfg.ProjectType.IsNode() {
+		if err := checkNodeSDKVersion(cfg); err != nil {
+			return nil, err
+		}
+	} else if err := agentfs.CheckSDKVersion(cfg.Dir, cfg.ProjectType, map[string]string{
 		"python-min-sdk-version": thinCLIMinVersion,
 		"node-min-sdk-version":   thinCLIMinVersion,
 	}); err != nil {

--- a/cmd/lk/simulate_tui.go
+++ b/cmd/lk/simulate_tui.go
@@ -78,8 +78,12 @@ func runSimulateTUI(config *simulateConfig) error {
 		out.Statusf("Dashboard:  %s", url)
 	}
 
-	if m.runID != "" && !m.runFinished {
+	if m.config.mode == modeView {
+		fmt.Fprintf(os.Stderr, "To re-open this simulation, run: lk agent simulate --view %s\n", m.config.viewModeRunID)
+	} else if m.runID != "" && !m.runFinished {
 		cancelSimulationRun(config.client, m.runID)
+	} else if m.runID != "" {
+		fmt.Fprintf(os.Stderr, "To re-open this simulation, run: lk agent simulate --view %s\n", m.runID)
 	}
 
 	if runErr != nil {
@@ -344,6 +348,18 @@ func (m *simulateModel) Init() tea.Cmd {
 func (m *simulateModel) runSetup() tea.Cmd {
 	c := m.config
 
+	if c.mode == modeView {
+		ctx, cancel := context.WithTimeout(context.Background(), simulationAPITimeout)
+		defer cancel()
+		run, err := getSimulationRun(ctx, m.config.client, m.config.viewModeRunID)
+		if err != nil {
+			m.err = err
+		}
+		m.run = run
+		m.setupDone = true
+		return nil
+	}
+
 	m.steps = nil
 	if c.mode == modeScenarios && c.scenarioGroup != nil {
 		// loaded before the TUI started, so it renders as already done
@@ -423,7 +439,7 @@ func (m *simulateModel) waitAgentReadyCmd() tea.Cmd {
 		case <-m.agent.Ready():
 			return agentReadyMsg{elapsed: time.Since(stepStart)}
 		case <-m.agent.Done():
-			return agentReadyMsg{err: fmt.Errorf("the agent exited before registering.\n\n%s", agentExitDetail(m.agent))}
+			return agentReadyMsg{err: fmt.Errorf("the agent exited before registering.\n\nCommand used to start agent: %s\n\n%s", m.agent.cmd.String(), agentExitDetail(m.agent))}
 		case <-timeout.C:
 			m.agent.Kill()
 			return agentReadyMsg{err: fmt.Errorf("timed out after %s waiting for the agent to register.\n\n%s", agentRegisterTimeout, agentExitDetail(m.agent))}
@@ -511,7 +527,10 @@ func (m *simulateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case agentReadyMsg:
 		if msg.err != nil {
 			m.failSetupStep(msg.err)
-			return m, nil
+			if m.setupCancel != nil {
+				m.setupCancel()
+			}
+			return m, tea.Quit
 		}
 		m.reporter.AgentRegistered(msg.elapsed)
 		m.advanceSetupStep(msg.elapsed)
@@ -783,7 +802,7 @@ func (m *simulateModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.scrollActive(-pageScroll, true)
 	case "pgdown":
 		m.scrollActive(pageScroll, true)
-	case "enter":
+	case "enter", "right":
 		if m.detailJobID == "" {
 			jobs := m.filteredJobs()
 			if m.cursor >= 0 && m.cursor < len(jobs) {
@@ -791,7 +810,7 @@ func (m *simulateModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.detailScrollOff = 0
 			}
 		}
-	case "esc", "backspace":
+	case "esc", "left", "backspace":
 		if m.detailJobID != "" {
 			m.detailJobID = ""
 			m.detailScrollOff = 0
@@ -1746,7 +1765,7 @@ func (m *simulateModel) renderHint() string {
 	var parts []string
 	switch {
 	case m.detailJobID != "":
-		parts = append(parts, "↑↓ scroll · c copy scenario · ESC back")
+		parts = append(parts, "↑↓ scroll · c copy scenario · ESC/← back")
 		if m.hasLogs() {
 			if m.showLogs {
 				parts = append(parts, "Ctrl+L hide logs")
@@ -1758,7 +1777,7 @@ func (m *simulateModel) renderHint() string {
 		parts = append(parts, "↑↓ scroll · d collapse description")
 	default:
 		// the collapsed description block already carries "(press d to expand)"
-		nav := "↑↓ navigate · ENTER detail"
+		nav := "↑↓ navigate · ENTER/→ detail"
 		if m.canExportScenarios() {
 			nav += " · s save scenarios"
 		}

--- a/pkg/agentfs/sdk_version_check.go
+++ b/pkg/agentfs/sdk_version_check.go
@@ -205,7 +205,7 @@ func checkRequirementsFile(filePath, minVersion string) VersionCheckResult {
 
 		version, found := parsePythonPackageVersion(line)
 		if found {
-			satisfied, err := isVersionSatisfied(version, minVersion)
+			satisfied, err := IsVersionSatisfied(version, minVersion)
 			return VersionCheckResult{
 				PackageInfo: PackageInfo{
 					Name:        "livekit-agents",
@@ -243,7 +243,7 @@ func checkPyprojectToml(filePath, minVersion string) VersionCheckResult {
 				if line, ok := dep.(string); ok {
 					version, found := parsePythonPackageVersion(line)
 					if found {
-						satisfied, err := isVersionSatisfied(version, minVersion)
+						satisfied, err := IsVersionSatisfied(version, minVersion)
 						return VersionCheckResult{
 							PackageInfo: PackageInfo{
 								Name:        "livekit-agents",
@@ -281,7 +281,7 @@ func checkPipfile(filePath, minVersion string) VersionCheckResult {
 			version = "latest"
 		}
 
-		satisfied, err := isVersionSatisfied(version, minVersion)
+		satisfied, err := IsVersionSatisfied(version, minVersion)
 		return VersionCheckResult{
 			PackageInfo: PackageInfo{
 				Name:        "livekit-agents",
@@ -326,7 +326,7 @@ func checkSetupPy(filePath, minVersion string) VersionCheckResult {
 				}
 				version, found := parsePythonPackageVersion(packageLine)
 				if found {
-					satisfied, err := isVersionSatisfied(version, minVersion)
+					satisfied, err := IsVersionSatisfied(version, minVersion)
 					return VersionCheckResult{
 						PackageInfo: PackageInfo{
 							Name:        "livekit-agents",
@@ -360,7 +360,7 @@ func checkSetupCfg(filePath, minVersion string) VersionCheckResult {
 	if matches != nil {
 		version := strings.TrimSpace(matches[2])
 
-		satisfied, err := isVersionSatisfied(version, minVersion)
+		satisfied, err := IsVersionSatisfied(version, minVersion)
 		return VersionCheckResult{
 			PackageInfo: PackageInfo{
 				Name:        "livekit-agents",
@@ -407,7 +407,7 @@ func checkPackageJSON(filePath, minVersion string) VersionCheckResult {
 
 	for _, deps := range dependencyMaps {
 		if version, ok := deps["@livekit/agents"]; ok {
-			satisfied, err := isVersionSatisfied(version, minVersion)
+			satisfied, err := IsVersionSatisfied(version, minVersion)
 			return VersionCheckResult{
 				PackageInfo: PackageInfo{
 					Name:        "@livekit/agents",
@@ -467,7 +467,7 @@ func checkPackageLockJSON(filePath, minVersion string) VersionCheckResult {
 	}
 
 	if dep, ok := lockJSON.Dependencies["@livekit/agents"]; ok {
-		satisfied, err := isVersionSatisfied(dep.Version, minVersion)
+		satisfied, err := IsVersionSatisfied(dep.Version, minVersion)
 		return VersionCheckResult{
 			PackageInfo: PackageInfo{
 				Name:        "@livekit/agents",
@@ -497,7 +497,7 @@ func checkYarnLock(filePath, minVersion string) VersionCheckResult {
 	matches := pattern.FindStringSubmatch(string(content))
 	if matches != nil {
 		version := matches[1]
-		satisfied, err := isVersionSatisfied(version, minVersion)
+		satisfied, err := IsVersionSatisfied(version, minVersion)
 		return VersionCheckResult{
 			PackageInfo: PackageInfo{
 				Name:        "@livekit/agents",
@@ -527,7 +527,7 @@ func checkPnpmLock(filePath, minVersion string) VersionCheckResult {
 	matches := pattern.FindStringSubmatch(string(content))
 	if matches != nil {
 		version := strings.TrimSpace(matches[1])
-		satisfied, err := isVersionSatisfied(version, minVersion)
+		satisfied, err := IsVersionSatisfied(version, minVersion)
 		return VersionCheckResult{
 			PackageInfo: PackageInfo{
 				Name:        "@livekit/agents",
@@ -557,7 +557,7 @@ func checkPoetryLock(filePath, minVersion string) VersionCheckResult {
 	matches := pattern.FindStringSubmatch(string(content))
 	if matches != nil {
 		version := matches[1]
-		satisfied, err := isVersionSatisfied(version, minVersion)
+		satisfied, err := IsVersionSatisfied(version, minVersion)
 		return VersionCheckResult{
 			PackageInfo: PackageInfo{
 				Name:        "livekit-agents",
@@ -587,7 +587,7 @@ func checkUvLock(filePath, minVersion string) VersionCheckResult {
 	matches := pattern.FindStringSubmatch(string(content))
 	if matches != nil {
 		version := matches[1]
-		satisfied, err := isVersionSatisfied(version, minVersion)
+		satisfied, err := IsVersionSatisfied(version, minVersion)
 		return VersionCheckResult{
 			PackageInfo: PackageInfo{
 				Name:        "livekit-agents",
@@ -617,7 +617,7 @@ func checkPipfileLock(filePath, minVersion string) VersionCheckResult {
 	matches := pattern.FindStringSubmatch(string(content))
 	if matches != nil {
 		version := matches[1]
-		satisfied, err := isVersionSatisfied(version, minVersion)
+		satisfied, err := IsVersionSatisfied(version, minVersion)
 		return VersionCheckResult{
 			PackageInfo: PackageInfo{
 				Name:        "livekit-agents",
@@ -635,8 +635,8 @@ func checkPipfileLock(filePath, minVersion string) VersionCheckResult {
 	return VersionCheckResult{}
 }
 
-// isVersionSatisfied checks if a version satisfies the minimum requirement
-func isVersionSatisfied(version, minVersion string) (bool, error) {
+// IsVersionSatisfied checks if a version satisfies the minimum requirement
+func IsVersionSatisfied(version, minVersion string) (bool, error) {
 	// Handle special cases
 	if version == "latest" || version == "*" || version == "" || version == "next" {
 		return true, nil // Latest version always satisfies

--- a/pkg/agentfs/sdk_version_check_test.go
+++ b/pkg/agentfs/sdk_version_check_test.go
@@ -230,7 +230,7 @@ func TestIsVersionSatisfied(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.version+"_vs_"+tt.minVersion, func(t *testing.T) {
-			result, err := isVersionSatisfied(tt.version, tt.minVersion)
+			result, err := IsVersionSatisfied(tt.version, tt.minVersion)
 
 			if tt.expectErr {
 				if err == nil {


### PR DESCRIPTION
Ports our simulate work onto the Node-support branch (`brian/agent-session-node-support`). These changes originated on an older fork of the simulate TUI, so they're re-applied as fresh edits rather than cherry-picks.

## Agent start / Node support
- Use `normalizeLogLevel` for the agent's `--log-level`.
- Only pass `--log-format colored` for Python (the Node CLI rejects it).
- Default Node entrypoints `main.ts` / `src/main.js` (and `src/` fallbacks).
- Refuse entrypoint auto-discovery when `package.json` defines a `build` task and no entrypoint was given (build output paths are nontrivial).
- Drop the Python-only guard so Node agents can be simulated.

## `lk agent simulate --view <runID>`
- New `--view` flag / `modeView` to open a pre-existing simulation.
- Print the reopen command (`lk agent simulate --view <runID>`) when the TUI closes.

## TUI UX
- `→` / `enter` to open a simulation's detail; `←` / `esc` / `backspace` to go back (hints updated).
- Richer agent-exit errors: include the command used to start the agent and its recent output (or "exited with no output").
- Quit the TUI when the agent fails to register instead of hanging.

Intentionally **not** ported (already present in a different form on this branch): the `exit()`/`confirmQuit` refactor and the `s` save-scenario key — this branch has its own save overlay and quit handling.

Builds clean with `go build` and `go vet -tags console`.