### PR TITLE
fix(agent init): surface dependency install failures clearly + don't show install command if the cli installed deps

### DIFF
--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -457,6 +457,10 @@ func setupTemplate(ctx context.Context, cmd *cli.Command) error {
 			}
 			fmt.Fprintf(&b, "%sFix your toolchain, then re-run the install step manually in ./%s.", fixPrefix, appName)
 			out.Warnf("%s", b.String())
+		} else {
+			// Signal a successful install to post_create so the template can skip
+			// printing the now-redundant install hint (guarded via `status:`).
+			os.Setenv("LIVEKIT_DEPS_INSTALLED", "1")
 		}
 	}
 	if err := doPostCreate(ctx, cmd, appName, verbose); err != nil {

--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -15,15 +15,18 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"regexp"
 	"strings"
 
 	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/urfave/cli/v3"
 
 	"github.com/livekit/livekit-cli/v2/pkg/bootstrap"
@@ -438,7 +441,22 @@ func setupTemplate(ctx context.Context, cmd *cli.Command) error {
 	if install {
 		out.Status("Installing template...")
 		if err := doInstall(ctx, bootstrap.TaskInstall, appName, verbose); err != nil {
-			out.Warnf("Warning: installation failed: %v", err)
+			// Installation is best-effort — the agent is still created below. But a
+			// failed install (e.g. missing Node/pnpm) is easy to miss once the
+			// template's post-create step prints "agent created", so render a
+			// prominent warning. Each line of the underlying command's error gets
+			// a red bar prefix so the actual failure stands out from the guidance.
+			header := lipgloss.NewStyle().Foreground(util.Warning()).Bold(true).
+				Render("⚠  Installation failed — dependencies were NOT installed")
+			errPrefix := lipgloss.NewStyle().Foreground(util.Error()).Render("┃ ")
+			fixPrefix := lipgloss.NewStyle().Foreground(util.Warning()).Render("┃ ")
+			var b strings.Builder
+			b.WriteString(header + "\n")
+			for _, line := range strings.Split(strings.TrimRight(err.Error(), "\n"), "\n") {
+				b.WriteString(errPrefix + line + "\n")
+			}
+			fmt.Fprintf(&b, "%sFix your toolchain, then re-run the install step manually in ./%s.", fixPrefix, appName)
+			out.Warnf("%s", b.String())
 		}
 	}
 	if err := doPostCreate(ctx, cmd, appName, verbose); err != nil {
@@ -594,12 +612,21 @@ func doPostCreate(ctx context.Context, _ *cli.Command, rootPath string, verbose 
 }
 
 func doInstall(ctx context.Context, task bootstrap.KnownTask, rootPath string, verbose bool) error {
-	tf, err := bootstrap.ParseTaskfile(rootPath)
-	if err != nil {
+	// Capture the task's stderr so a failure can report the underlying command's
+	// own error (e.g. "env: node: No such file or directory") rather than just
+	// go-task's "exit status N" wrapper. Under --verbose the output also streams
+	// live to the terminal.
+	exe := bootstrap.NewTaskExecutor(rootPath, verbose)
+	var stderr bytes.Buffer
+	if verbose {
+		exe.Stderr = io.MultiWriter(os.Stderr, &stderr)
+	} else {
+		exe.Stderr = &stderr
+	}
+	if err := exe.Setup(); err != nil {
 		return err
 	}
-
-	install, err := bootstrap.NewTask(ctx, tf, rootPath, string(task), verbose)
+	install, err := bootstrap.NewTaskWithExecutor(ctx, exe, string(task), verbose)
 	if err != nil {
 		return err
 	}
@@ -612,6 +639,9 @@ func doInstall(ctx context.Context, task bootstrap.KnownTask, rootPath string, v
 		},
 	)
 	if err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return errors.New(msg)
+		}
 		return err
 	}
 	return nil

--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -451,12 +451,14 @@ func setupTemplate(ctx context.Context, cmd *cli.Command) error {
 			errPrefix := lipgloss.NewStyle().Foreground(util.Error()).Render("┃ ")
 			fixPrefix := lipgloss.NewStyle().Foreground(util.Warning()).Render("┃ ")
 			var b strings.Builder
-			b.WriteString(header + "\n")
+			b.WriteString(header)
+			b.WriteString("\n")
 			for _, line := range strings.Split(strings.TrimRight(err.Error(), "\n"), "\n") {
-				b.WriteString(errPrefix + line + "\n")
+				b.WriteString(errPrefix)
+				b.WriteString(line)
+				b.WriteString("\n")
 			}
-			fmt.Fprintf(&b, "%sFix your toolchain, then re-run the install step manually in ./%s.", fixPrefix, appName)
-			out.Warnf("%s", b.String())
+			out.Warnf("%s%sFix your toolchain, then re-run the install step manually in ./%s.", b.String(), fixPrefix, appName)
 		} else {
 			// Signal a successful install to post_create so the template can skip
 			// printing the now-redundant install hint (guarded via `status:`).


### PR DESCRIPTION
## Summary

Improves how `lk agent init` (and `lk app create`) handles the dependency-install step.

Previously a failed install (e.g. missing Node/pnpm) was downgraded to a single-line warning and the command still exited 0, so it was easy to miss — buried between status lines and the template's "agent created" banner.

This branch:

1. **Surfaces install failures prominently.** `doInstall` now captures the install task's stderr and reports the underlying command's own error (e.g. `env: node: No such file or directory`) instead of go-task's generic `exit status N` wrapper. The failure is rendered as a bold header with a red bar prefix on each error line and a yellow bar on the follow-up guidance. The agent is still created (install is best-effort).

2. **Signals a successful install to `post_create`.** On success, sets `LIVEKIT_DEPS_INSTALLED=1` so a template's `post_create` task can skip the now-redundant install hint (e.g. `pnpm install`) via a `status:` guard — mirroring how `LIVEKIT_AGENT_NAME`/`LIVEKIT_SANDBOX_ID` already gate template output. No-op until the template opts in (companion PR on `agent-starter-node`).

## Before / after (failure)

```
# before
Warning: installation failed: task: Failed to run task "install": exit status 127   (exit 0)

# after
⚠  Installation failed — dependencies were NOT installed
┃ env: node: No such file or directory
┃ Fix your toolchain, then re-run the install step manually in ./my-agent.
```

## Testing

- Verified the failure path renders the real command error.
- Verified `LIVEKIT_DEPS_INSTALLED=1` makes a `status:`-guarded template skip the install hint on success and keep it when install isn't run.