### PR TITLE
Default 'Install dependencies?' prompt to yes in agent create TUI

### DIFF
--- a/cmd/lk/app.go
+++ b/cmd/lk/app.go
@@ -430,6 +430,8 @@ func setupTemplate(ctx context.Context, cmd *cli.Command) error {
 	bootstrap.WriteDotEnv(appName, envOutputFile, env, true)
 
 	if !cmd.IsSet("install") && !SkipPrompts(cmd) {
+		// Default the prompt to "yes" — installing deps is the common case.
+		install = true
 		if err := huh.NewForm(huh.NewGroup(util.Confirm().
 			Title("Install dependencies?").
 			Value(&install).


### PR DESCRIPTION
## What

When running `lk agent create` interactively, the **Install dependencies?** confirm now defaults to **Yes** instead of **No**.

## Why

The confirm is a `huh.Select[bool]` whose cursor is seeded from the bound `install` value. That value came from `cmd.Bool("install")`, which is `false` when the `--install` flag isn't passed — so the prompt opened on **No**. Installing deps is the common case, so it should be the default.

## Behavior

- `lk agent create` (interactive, no flag) → prompt now defaults to **Yes**.
- `--install` / `--install=false` → unchanged; the explicit flag short-circuits the prompt entirely.
- non-interactive (`SkipPrompts`) without the flag → unchanged.