### PR TITLE
feat(release): sign checksums.txt with cosign keyless signing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,9 @@ on:
 
 permissions:
   contents: write
+  # id-token lets cosign obtain a GitHub OIDC token for keyless (Sigstore)
+  # signing of checksums.txt during the goreleaser step.
+  id-token: write
 
 jobs:
   # GoReleaser runs on macOS so the darwin binary builds natively (CoreAudio
@@ -91,6 +94,9 @@ jobs:
         with:
           path: .cross
           key: cross-${{ runner.os }}-zig0.14.1-alsa1.2.12-${{ hashFiles('scripts/setup-cross.sh') }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,9 +21,6 @@ on:
 
 permissions:
   contents: write
-  # id-token lets cosign obtain a GitHub OIDC token for keyless (Sigstore)
-  # signing of checksums.txt during the goreleaser step.
-  id-token: write
 
 jobs:
   # GoReleaser runs on macOS so the darwin binary builds natively (CoreAudio
@@ -33,6 +30,13 @@ jobs:
   release:
     name: Release
     runs-on: macos-latest
+    # id-token lets cosign obtain a GitHub OIDC token for keyless (Sigstore)
+    # signing of checksums.txt during the goreleaser step. Scoped to this job
+    # only: the Fulcio certificate identity is per-workflow, not per-job, so
+    # any job holding id-token could sign as the identity installers trust.
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout Git LFS
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -161,5 +161,27 @@ gomod:
 checksum:
   name_template: 'checksums.txt'
 
+# Keyless (Sigstore) signing: cosign signs checksums.txt with the release
+# workflow's GitHub OIDC identity — no long-lived key to manage. Every archive
+# is listed in checksums.txt, so one signature covers all release artifacts.
+# Verify with:
+#   cosign verify-blob \
+#     --certificate checksums.txt.pem --signature checksums.txt.sig \
+#     --certificate-identity-regexp '^https://github.com/livekit/livekit-cli/\.github/workflows/release\.yaml@.*$' \
+#     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+#     checksums.txt
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - --output-signature=${signature}
+      - --output-certificate=${certificate}
+      - --yes
+      - ${artifact}
+    artifacts: checksum
+    output: true
+
 snapshot:
   version_template: "{{ incpatch .Version }}-next"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -164,10 +164,11 @@ checksum:
 # Keyless (Sigstore) signing: cosign signs checksums.txt with the release
 # workflow's GitHub OIDC identity — no long-lived key to manage. Every archive
 # is listed in checksums.txt, so one signature covers all release artifacts.
-# Verify with:
+# Verify with (substitute the exact version you downloaded — pinning the tag
+# rejects signatures replayed from a different, older release):
 #   cosign verify-blob \
 #     --certificate checksums.txt.pem --signature checksums.txt.sig \
-#     --certificate-identity-regexp '^https://github.com/livekit/livekit-cli/\.github/workflows/release\.yaml@.*$' \
+#     --certificate-identity "https://github.com/livekit/livekit-cli/.github/workflows/release.yaml@refs/tags/v<VERSION>" \
 #     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
 #     checksums.txt
 signs:

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -73,10 +73,36 @@ trap 'rm -rf "$TEMP_DIR"' EXIT
 curl -fsSL "$ARCHIVE_URL" -o "$TEMP_DIR/$ARCHIVE_NAME"
 curl -fsSL "$CHECKSUMS_URL" -o "$TEMP_DIR/checksums.txt"
 
+# When cosign is available, verify the Sigstore signature on checksums.txt. The
+# certificate identity is pinned to this repo's release workflow running for this
+# exact version tag, so a valid signature proves the checksums were produced by
+# livekit-cli's release CI and not substituted alongside a tampered archive.
+# Releases published before signing was introduced have no .sig/.pem assets, so a
+# missing signature is skipped rather than fatal; a present-but-invalid one aborts.
+if command -v cosign >/dev/null; then
+  # No -S here: a 404 is the expected outcome for releases that predate signing,
+  # so curl's error output would just be noise.
+  if curl -fsL "$CHECKSUMS_URL.sig" -o "$TEMP_DIR/checksums.txt.sig" &&
+     curl -fsL "$CHECKSUMS_URL.pem" -o "$TEMP_DIR/checksums.txt.pem"; then
+    log "Verifying signature..."
+    cosign verify-blob \
+      --certificate "$TEMP_DIR/checksums.txt.pem" \
+      --signature "$TEMP_DIR/checksums.txt.sig" \
+      --certificate-identity-regexp "^https://github.com/livekit/$REPO/\.github/workflows/release\.yaml@refs/tags/v${VERSION}$" \
+      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+      "$TEMP_DIR/checksums.txt" \
+      || abort "Signature verification failed for checksums.txt"
+  else
+    log "No signature published for this release; skipping signature verification."
+  fi
+else
+  log "cosign not found; skipping signature verification."
+fi
+
 # Verify the archive against the release's checksums.txt before extracting. The checksums
 # file is fetched from the same release over HTTPS, so this guards against corrupted/partial
-# downloads and accidental mismatches; it is not a substitute for signature verification
-# against an out-of-band key.
+# downloads and accidental mismatches; when cosign is absent it is not a substitute for
+# signature verification against an out-of-band key.
 log "Verifying checksum..."
 expected_sum=$(awk -v f="$ARCHIVE_NAME" '$2 == f {print $1}' "$TEMP_DIR/checksums.txt")
 [ -n "$expected_sum" ] || abort "Could not find a checksum for $ARCHIVE_NAME in checksums.txt"

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -108,7 +108,7 @@ if command -v cosign >/dev/null; then
     cosign verify-blob \
       --certificate "$TEMP_DIR/checksums.txt.pem" \
       --signature "$TEMP_DIR/checksums.txt.sig" \
-      --certificate-identity-regexp "^https://github.com/livekit/$REPO/\.github/workflows/release\.yaml@refs/tags/v${VERSION}$" \
+      --certificate-identity "https://github.com/livekit/$REPO/.github/workflows/release.yaml@refs/tags/v${VERSION}" \
       --certificate-oidc-issuer https://token.actions.githubusercontent.com \
       "$TEMP_DIR/checksums.txt" \
       || abort "Signature verification failed for checksums.txt"

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -77,13 +77,33 @@ curl -fsSL "$CHECKSUMS_URL" -o "$TEMP_DIR/checksums.txt"
 # certificate identity is pinned to this repo's release workflow running for this
 # exact version tag, so a valid signature proves the checksums were produced by
 # livekit-cli's release CI and not substituted alongside a tampered archive.
-# Releases published before signing was introduced have no .sig/.pem assets, so a
-# missing signature is skipped rather than fatal; a present-but-invalid one aborts.
+#
+# Every release after v$LAST_UNSIGNED_VERSION publishes checksums.txt.sig/.pem,
+# so for those a missing signature means the assets were tampered with (an
+# attacker stripping the signature to force a checksum-only fallback) and is
+# fatal. Only releases predating signing may legitimately lack one, and only a
+# clean 404 counts as "not published" — transport errors and other HTTP
+# failures abort rather than silently skipping verification.
+#
+# NOTE for maintainers: if a release ships between this script landing and the
+# signing config landing, bump LAST_UNSIGNED_VERSION to that release.
+LAST_UNSIGNED_VERSION="2.17.0"
+
+version_gt() {
+  [ "$1" != "$2" ] && [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+}
+
+# Downloads $1 to $2 and prints the final HTTP status code; transport failures
+# (DNS, TLS, reset) print curl's 000. Never returns non-zero, so callers can
+# branch on the status code under errexit.
+fetch_status() {
+  curl -fsL -o "$2" -w '%{http_code}' "$1" 2>/dev/null || true
+}
+
 if command -v cosign >/dev/null; then
-  # No -S here: a 404 is the expected outcome for releases that predate signing,
-  # so curl's error output would just be noise.
-  if curl -fsL "$CHECKSUMS_URL.sig" -o "$TEMP_DIR/checksums.txt.sig" &&
-     curl -fsL "$CHECKSUMS_URL.pem" -o "$TEMP_DIR/checksums.txt.pem"; then
+  sig_status=$(fetch_status "$CHECKSUMS_URL.sig" "$TEMP_DIR/checksums.txt.sig")
+  pem_status=$(fetch_status "$CHECKSUMS_URL.pem" "$TEMP_DIR/checksums.txt.pem")
+  if [ "$sig_status" = "200" ] && [ "$pem_status" = "200" ]; then
     log "Verifying signature..."
     cosign verify-blob \
       --certificate "$TEMP_DIR/checksums.txt.pem" \
@@ -92,8 +112,13 @@ if command -v cosign >/dev/null; then
       --certificate-oidc-issuer https://token.actions.githubusercontent.com \
       "$TEMP_DIR/checksums.txt" \
       || abort "Signature verification failed for checksums.txt"
+  elif [ "$sig_status" = "404" ] && [ "$pem_status" = "404" ]; then
+    if version_gt "$VERSION" "$LAST_UNSIGNED_VERSION"; then
+      abort "No signature published for v$VERSION, but every release after v$LAST_UNSIGNED_VERSION is signed; refusing to install."
+    fi
+    log "Release predates signing; skipping signature verification."
   else
-    log "No signature published for this release; skipping signature verification."
+    abort "Could not download the signature for checksums.txt (HTTP $sig_status/$pem_status)"
   fi
 else
   log "cosign not found; skipping signature verification."
@@ -101,8 +126,8 @@ fi
 
 # Verify the archive against the release's checksums.txt before extracting. The checksums
 # file is fetched from the same release over HTTPS, so this guards against corrupted/partial
-# downloads and accidental mismatches; when cosign is absent it is not a substitute for
-# signature verification against an out-of-band key.
+# downloads and accidental mismatches; unless the signature was verified above, it is not
+# a substitute for signature verification against an out-of-band key.
 log "Verifying checksum..."
 expected_sum=$(awk -v f="$ARCHIVE_NAME" '$2 == f {print $1}' "$TEMP_DIR/checksums.txt")
 [ -n "$expected_sum" ] || abort "Could not find a checksum for $ARCHIVE_NAME in checksums.txt"


### PR DESCRIPTION
Follow-up to #880, which verifies archives against `checksums.txt` — but the checksums file ships alongside the archive in the same release, so it can't detect substituted release assets. This PR signs releases so the checksums are bound to an identity an attacker can't forge.

## Approach: keyless (Sigstore) signing of `checksums.txt`

- **`.goreleaser.yaml`**: a `signs` section runs `cosign sign-blob` on `checksums.txt` during release. Keyless — cosign uses the release workflow's GitHub OIDC identity, so there is **no signing key to store or rotate**. Each release gains `checksums.txt.sig` + `checksums.txt.pem`, and the signature is recorded in the Rekor transparency log. Since every archive is listed in `checksums.txt`, one signature covers all release artifacts.
- **`.github/workflows/release.yaml`**: adds a `sigstore/cosign-installer` step (pinned by SHA, matching repo convention) and `id-token: write` **scoped to the `release` job only** — the Fulcio certificate identity is per-workflow, not per-job, so granting `id-token` workflow-wide would let the docker job's third-party actions mint the exact identity installers trust.
- **`install-cli.sh`**: when cosign is installed, verifies the signature with the certificate identity pinned (exact match, no regexp) to this repo's release workflow at the exact version tag. The check **fails closed** where it matters:
  - Missing `.sig`/`.pem` on any release after `v2.17.0` (the last unsigned release) **aborts** — an attacker who substitutes assets can't strip the signature to force a checksum-only fallback.
  - Only a clean 404 on a pre-signing release skips verification; transport errors and other HTTP failures abort instead of being conflated with "not published".
  - When cosign is absent, it logs a skip and falls back to checksum-only — nothing breaks for users without cosign or for existing releases.

Manual verification for users (substitute the exact version you downloaded — pinning the tag rejects signatures replayed from an older release):

```bash
cosign verify-blob \
  --certificate checksums.txt.pem --signature checksums.txt.sig \
  --certificate-identity "https://github.com/livekit/livekit-cli/.github/workflows/release.yaml@refs/tags/v<VERSION>" \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  checksums.txt
```

## Testing

- `goreleaser check` passes on the modified config.
- The installer's signature block was exercised in isolation across all paths: no cosign → skip; pre-signing release (404) → skip; post-`v2.17.0` release with missing signature → abort; transport error / mixed HTTP statuses → abort; valid sig → continue; invalid sig → abort.
- `fetch_status` (the HTTP-status-aware download helper) tested against the real v2.17.0 release assets: 200 for `checksums.txt`, 404 for the nonexistent `.sig`, 000 on transport failure — all without tripping `errexit`.
- Full installer run end-to-end in an Ubuntu container against the real v2.17.0 release, both with and without cosign installed (pre-hardening revision).
- **Not testable from a fork**: the signing step itself needs a real tag push with GitHub OIDC in this repo. A maintainer could confirm with a pre-release tag (e.g. `v0.0.0-signing-test`) before the next real release.

> **Note for maintainers**: if a release ships before this PR lands, bump `LAST_UNSIGNED_VERSION` in `install-cli.sh` to that release.

## Possible follow-ups (out of scope here)

- Emit a Sigstore bundle (`--bundle`) at sign time and verify with `--bundle --offline`, removing the per-install Rekor lookup and TUF fetch (also de-flakes `install-test.yaml`, which runs the installer with cosign on every PR).
- Version-gate the cosign check so a stale cosign 1.x (no `--certificate-identity` flag) skips with a message instead of hard-aborting.
- cosign-sign the Docker images in the `docker` job (same keyless flow on the pushed digest).
- GitHub artifact attestations (`actions/attest-build-provenance`) as a cheap complement — users could verify with `gh attestation verify`.
