### PR TITLE
give session e2e start the CLI's own readiness budget

### DIFF
--- a/cmd/lk/session_e2e_test.go
+++ b/cmd/lk/session_e2e_test.go
@@ -103,7 +103,11 @@ func TestSessionE2E(t *testing.T) {
 	})
 
 	// start: launches the detached daemon and returns once the agent is ready.
-	startOut, err := run(15*time.Second, "agent", "daemon", "start", "--port", port, entrypoint)
+	// The CLI itself waits up to 65s for daemon readiness (awaitDaemonReady),
+	// so give it just over that: on a cold Windows runner the chain of first
+	// execs (lk.exe, uv, python) can alone eat a tighter budget, and killing
+	// the command mid-wait loses the CLI's own error report.
+	startOut, err := run(70*time.Second, "agent", "daemon", "start", "--port", port, entrypoint)
 	require.NoError(t, err, "session start failed:\n%s", startOut)
 	require.Contains(t, startOut, "Session started.", "start did not report readiness:\n%s", startOut)
 


### PR DESCRIPTION
Fixes the Windows session e2e flake where `TestSessionE2E` fails with an empty `session start failed:` / `exit status 1` at exactly 15s (e.g. [this run](https://github.com/livekit/livekit-cli/actions/runs/29215177932/job/86710236307)).

**Root cause:** the test capped `agent daemon start` at 15s, but the CLI itself budgets 65s for daemon readiness (`awaitDaemonReady`, matching the daemon's 60s agent-connect timeout). On a cold Windows runner, the first exec of each binary in the chain is Defender-scanned — the freshly downloaded `lk.exe`, then `uv`/`python` for the version probe and the agent itself — so the whole startup (spawn daemon → SDK version probe → spawn agent → import `livekit.agents` → connect to LiveKit) can exceed 15s with every step succeeding. The test's context deadline then kills the command mid-wait, which is why the failure carries no output.

**Fix:** give the start step 70s, just over the CLI's own budget, so the test only fails when the CLI itself would report a startup error instead of racing it with a stricter deadline. The earlier node pre-warm (a9030dc) couldn't help here: it lives in `TestAgentProcessFailSignal`, which the session e2e job filters out with `-test.run TestSessionE2E`, and the flaking arm is Python anyway.