### PR TITLE
Carry --server-url over to the printed --view command on simulate exit

### DIFF
--- a/cmd/lk/simulate.go
+++ b/cmd/lk/simulate.go
@@ -559,6 +559,17 @@ func dashboardBaseURL() string {
 	return dashboardURL
 }
 
+// viewCommandHint returns the command to re-open a simulation run, carrying
+// over --server-url when the run lives somewhere other than the default cloud
+// API (e.g. staging), so the printed command targets the same environment.
+func viewCommandHint(runID string) string {
+	hint := "lk agent simulate --view " + runID
+	if serverURL != cloudAPIServerURL {
+		hint += " --server-url " + serverURL
+	}
+	return hint
+}
+
 func simulationDashboardURL(projectID, runID string) string {
 	if projectID == "" || runID == "" {
 		return ""

--- a/cmd/lk/simulate_tui.go
+++ b/cmd/lk/simulate_tui.go
@@ -80,11 +80,11 @@ func runSimulateTUI(config *simulateConfig) error {
 	}
 
 	if m.config.mode == modeView {
-		fmt.Fprintf(os.Stderr, "To re-open this simulation, run: lk agent simulate --view %s\n", m.config.viewModeRunID)
+		fmt.Fprintf(os.Stderr, "To re-open this simulation, run: %s\n", viewCommandHint(m.config.viewModeRunID))
 	} else if m.runID != "" && !m.runFinished {
 		cancelSimulationRun(config.client, m.runID)
 	} else if m.runID != "" {
-		fmt.Fprintf(os.Stderr, "To re-open this simulation, run: lk agent simulate --view %s\n", m.runID)
+		fmt.Fprintf(os.Stderr, "To re-open this simulation, run: %s\n", viewCommandHint(m.runID))
 	}
 
 	if runErr != nil {


### PR DESCRIPTION
When a simulation run exits, the CLI prints a hint like `To re-open this simulation, run: lk agent simulate --view SR_...`. If the original command targeted a non-default API server via `--server-url` (e.g. staging), the printed command previously dropped that flag, so copy-pasting it would look up the run in the wrong environment.

This adds a `viewCommandHint` helper that appends `--server-url` whenever the active server differs from the default cloud API, and uses it for both exit paths in the TUI.