### PR TITLE
feat(simulate): QOL — quota surfacing, wrapped errors, argv[0] in view hint

### DIFF
--- a/cmd/lk/console_tui.go
+++ b/cmd/lk/console_tui.go
@@ -470,9 +470,13 @@ func (m *consoleModel) handleSessionEvent(ev *agent.AgentSessionEvent) []tea.Cmd
 			b.WriteString(fc.Name)
 			if fco, ok := outputsByCallID[fc.CallId]; ok {
 				if fco.IsError {
-					b.WriteString("\n    ")
-					b.WriteString(redBoldStyle().Render("✗ "))
-					b.WriteString(redStyle().Render(truncateOutput(fco.Output)))
+					for j, line := range wrapLines(truncateOutput(fco.Output), m.width-6) {
+						if j == 0 {
+							b.WriteString("\n    " + redBoldStyle().Render("✗ ") + redStyle().Render(line))
+						} else {
+							b.WriteString("\n      " + redStyle().Render(line))
+						}
+					}
 				} else {
 					b.WriteString("\n    ")
 					b.WriteString(greenStyle().Render("✓ "))
@@ -484,9 +488,18 @@ func (m *consoleModel) handleSessionEvent(ev *agent.AgentSessionEvent) []tea.Cmd
 		cmds = append(cmds, tea.Println(b.String()))
 
 	case *agent.AgentSessionEvent_Error_:
-		cmds = append(cmds, tea.Println(
-			"  "+redBoldStyle().Render("✗ ")+redStyle().Render(e.Error.Message),
-		))
+		var b strings.Builder
+		for i, line := range wrapLines(e.Error.Message, m.width-4) {
+			if i > 0 {
+				b.WriteString("\n")
+			}
+			if i == 0 {
+				b.WriteString("  " + redBoldStyle().Render("✗ ") + redStyle().Render(line))
+			} else {
+				b.WriteString("    " + redStyle().Render(line))
+			}
+		}
+		cmds = append(cmds, tea.Println(b.String()))
 	}
 
 	return cmds
@@ -572,9 +585,9 @@ func (m consoleModel) View() string {
 		}
 
 		if m.audioError != "" {
-			b.WriteString("\n")
-			b.WriteString("  ")
-			b.WriteString(redStyle().Render("audio: " + m.audioError))
+			for _, line := range wrapLines("audio: "+m.audioError, m.width-2) {
+				b.WriteString("\n  " + redStyle().Render(line))
+			}
 		}
 
 		if m.showShortcuts {

--- a/cmd/lk/main.go
+++ b/cmd/lk/main.go
@@ -95,7 +95,12 @@ func main() {
 
 	if err := app.Run(ctx, os.Args); err != nil {
 		errStyle := lipgloss.NewStyle().Foreground(util.Error())
-		fmt.Fprintln(os.Stderr, errStyle.Render(err.Error()))
+		// Render line by line: a multiline Render pads every line with
+		// trailing spaces to match the widest one, which wraps into garbage
+		// on terminals narrower than the longest line.
+		for line := range strings.SplitSeq(err.Error(), "\n") {
+			fmt.Fprintln(os.Stderr, errStyle.Render(line))
+		}
 		os.Exit(1)
 	}
 }

--- a/cmd/lk/simulate.go
+++ b/cmd/lk/simulate.go
@@ -578,8 +578,14 @@ func dashboardBaseURL() string {
 // viewCommandHint returns the command to re-open a simulation run, carrying
 // over --server-url when the run lives somewhere other than the default cloud
 // API (e.g. staging), so the printed command targets the same environment.
+// The binary name comes from argv[0] so a renamed or path-qualified lk is
+// reproduced verbatim.
 func viewCommandHint(runID string) string {
-	hint := "lk agent simulate --view " + runID
+	binary := "lk"
+	if len(os.Args) > 0 && os.Args[0] != "" {
+		binary = os.Args[0]
+	}
+	hint := binary + " agent simulate --view " + runID
 	if serverURL != cloudAPIServerURL {
 		hint += " --server-url " + serverURL
 	}

--- a/cmd/lk/simulate.go
+++ b/cmd/lk/simulate.go
@@ -287,6 +287,9 @@ func runSimulate(ctx context.Context, cmd *cli.Command) error {
 		}
 		liveAgent = true
 		agentName = liveAgentName
+	} else if runID != "" {
+		// --view opens a pre-existing run: nothing is spawned, so no agent
+		// project or entrypoint is needed.
 	} else {
 		agentName = generateAgentName()
 		projectDir, projectType, err = agentfs.DetectProjectRoot(".")

--- a/cmd/lk/simulate.go
+++ b/cmd/lk/simulate.go
@@ -181,9 +181,10 @@ type simulateConfig struct {
 	projectType    agentfs.ProjectType
 	entrypoint     string
 	scenarioGroup  *livekit.ScenarioGroup
-	scenariosPath  string // path to the --scenarios file (empty when generating from source)
-	viewModeRunID  string // non-empty when --view opens a pre-existing run
-	liveAgent      bool   // --agent-name: run against an already-running agent, don't spawn one
+	scenariosPath  string   // path to the --scenarios file (empty when generating from source)
+	viewModeRunID  string   // non-empty when --view opens a pre-existing run
+	liveAgent      bool     // --agent-name: run against an already-running agent, don't spawn one
+	warnings       []string // config-level warnings surfaced at setup (e.g. ignored flags)
 	// TODO (steveyoon): add agent deployment support
 	// agentDeployment string
 }
@@ -195,6 +196,17 @@ const (
 	modeGenerateFromSource
 	modeView
 )
+
+const numSimulationsIgnoredWarning = "--num-simulations has no effect when --scenarios is provided (it only controls scenario generation); did you mean --concurrency?"
+
+// simulateConfigWarnings flags configurations that silently do nothing, so the
+// user learns before the run burns quota.
+func simulateConfigWarnings(mode simulateMode, numSimulations int32) []string {
+	if mode == modeScenarios && numSimulations > 0 {
+		return []string{numSimulationsIgnoredWarning}
+	}
+	return nil
+}
 
 func loadScenarioGroup(path string) (*livekit.ScenarioGroup, error) {
 	data, err := os.ReadFile(path)
@@ -363,6 +375,7 @@ func runSimulate(ctx context.Context, cmd *cli.Command) error {
 		scenariosPath:  scenariosPath,
 		viewModeRunID:  runID,
 		liveAgent:      liveAgent,
+		warnings:       simulateConfigWarnings(mode, numSimulations),
 	}
 
 	if !isInteractive() {

--- a/cmd/lk/simulate_ci.go
+++ b/cmd/lk/simulate_ci.go
@@ -139,6 +139,8 @@ func runSimulateCI(ctx context.Context, config *simulateConfig) error {
 	// --- Poll until terminal ---
 
 	brokenAgent := false
+	quotaWarned := false
+	peakRunning := 0
 	ticker := time.NewTicker(simulationPollInterval)
 	defer ticker.Stop()
 
@@ -153,6 +155,19 @@ func runSimulateCI(ctx context.Context, config *simulateConfig) error {
 			}
 			out.Warnf("Warning: poll failed: %v", err)
 		} else {
+			if running := runningJobCount(run); running > peakRunning {
+				peakRunning = running
+			}
+			if !quotaWarned && agent != nil {
+				if info := detectQuotaExceeded(agent.RecentLogs(0)); info != nil {
+					quotaWarned = true
+					suggested := suggestConcurrency(config.concurrency, peakRunning)
+					out.Warnf("Warning: inference quota exceeded — this project is hitting its %s; LLM completions are failing with 429s. Suggested fix: re-run with --concurrency %d",
+						info.describe(), suggested)
+					report.QuotaExceeded(info.describe(), suggested)
+				}
+			}
+
 			// the worker is failing systemically (or, in live-agent mode, the
 			// agent never joined): stop early and surface its log
 			if !brokenAgent && agentBroken(run, agent) {

--- a/cmd/lk/simulate_ci.go
+++ b/cmd/lk/simulate_ci.go
@@ -74,6 +74,11 @@ func runSimulateCI(ctx context.Context, config *simulateConfig) error {
 	report := newSimLog(out.ResultWriter(), out.StatusWriter())
 	report.BeginSetup()
 
+	for _, w := range config.warnings {
+		out.Warnf("Warning: %s", w)
+		report.ConfigWarning(w)
+	}
+
 	var err error
 	if !config.liveAgent {
 		report.StartingAgent()

--- a/cmd/lk/simulate_ci.go
+++ b/cmd/lk/simulate_ci.go
@@ -39,6 +39,10 @@ func (tw *toggleWriter) Write(p []byte) (int, error) {
 }
 
 func runSimulateCI(ctx context.Context, config *simulateConfig) error {
+	if config.mode == modeView {
+		return runSimulateCIView(ctx, config)
+	}
+
 	ctx, stop := signal.NotifyContext(ctx, os.Interrupt)
 	defer stop()
 
@@ -193,8 +197,14 @@ func runSimulateCI(ctx context.Context, config *simulateConfig) error {
 		out.Statusf("Dashboard:  %s", url)
 	}
 
-	// the returned error is printed by main and reports the failure; the
-	// counts line / full dump above already carries the detail
+	return runFailureError(run)
+}
+
+// runFailureError converts a terminal run's failures into the CI exit error;
+// the error is printed by main and reports the failure — the counts line /
+// full dump above already carries the detail. Returns nil when everything
+// passed.
+func runFailureError(run *livekit.SimulationRun) error {
 	_, _, _, failed := simulationJobCounts(run)
 	if failed > 0 || run.Status == livekit.SimulationRun_STATUS_FAILED {
 		if run.Status == livekit.SimulationRun_STATUS_FAILED && len(run.Jobs) == 0 {
@@ -204,4 +214,52 @@ func runSimulateCI(ctx context.Context, config *simulateConfig) error {
 	}
 
 	return nil
+}
+
+// runSimulateCIView handles --view in non-interactive mode: it fetches the
+// pre-existing run (polling until it reaches a terminal state if it is still
+// in progress) and prints the report. Nothing is spawned or cancelled — the
+// run belongs to whoever created it.
+func runSimulateCIView(ctx context.Context, config *simulateConfig) error {
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt)
+	defer stop()
+
+	report := newSimLog(out.ResultWriter(), out.StatusWriter())
+	runID := config.viewModeRunID
+
+	ticker := time.NewTicker(simulationPollInterval)
+	defer ticker.Stop()
+
+	var run *livekit.SimulationRun
+	for {
+		pollCtx, pollCancel := context.WithTimeout(ctx, simulationAPITimeout)
+		var err error
+		run, err = getSimulationRun(pollCtx, config.client, runID)
+		pollCancel()
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return err
+		}
+
+		if isTerminalRunStatus(run.Status) {
+			break
+		}
+		report.RunUpdate(run, config.numSimulations)
+
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	report.Results(run, nil)
+
+	if url := simulationDashboardURL(config.pc.ProjectId, runID); url != "" {
+		out.Statusf("Dashboard:  %s", url)
+	}
+
+	return runFailureError(run)
 }

--- a/cmd/lk/simulate_health.go
+++ b/cmd/lk/simulate_health.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/livekit/protocol/livekit"
@@ -106,4 +107,72 @@ func isFatalMarker(line string) bool {
 		}
 	}
 	return false
+}
+
+// Inference-gateway quota exhaustion (HTTP 429) detection. When the LiveKit
+// Cloud gateway rate-limits LLM completions, every simulation job fails with a
+// generic "failed to generate LLM completion" — the real cause only appears in
+// the agent's log output, so the CLI scans for it and surfaces it.
+
+var quotaCategoryRe = regexp.MustCompile(`'?category'?:\s*'?([A-Za-z0-9_]+)'?`)
+
+type quotaInfo struct {
+	category string // raw gateway category, e.g. MaxConcurrentGatewayLLMTpm
+}
+
+// detectQuotaExceeded returns info about the first inference-quota error in
+// the agent's output, or nil if none appears.
+func detectQuotaExceeded(logs []string) *quotaInfo {
+	for _, line := range logs {
+		plain := ansiEscapeRe.ReplaceAllString(line, "")
+		if !strings.Contains(plain, "inference_quota_exceeded") &&
+			!strings.Contains(plain, "QuotaStatusExceeded") {
+			continue
+		}
+		info := &quotaInfo{}
+		if m := quotaCategoryRe.FindStringSubmatch(plain); m != nil {
+			info.category = m[1]
+		}
+		return info
+	}
+	return nil
+}
+
+// describe renders the gateway's quota category in plain words.
+func (q *quotaInfo) describe() string {
+	switch {
+	case strings.Contains(q.category, "Tpm"):
+		return "LLM tokens-per-minute rate limit"
+	case strings.Contains(q.category, "Rpm"):
+		return "LLM requests-per-minute rate limit"
+	case q.category != "":
+		return q.category + " rate limit"
+	default:
+		return "an inference rate limit"
+	}
+}
+
+// suggestConcurrency proposes half the current effective concurrency (never
+// below 1). Without an explicit --concurrency the server default applies, so
+// the caller passes the peak simultaneously-running job count it observed.
+func suggestConcurrency(configured int32, peakRunning int) int {
+	current := int(configured)
+	if current <= 0 {
+		current = peakRunning
+	}
+	if current/2 < 1 {
+		return 1
+	}
+	return current / 2
+}
+
+// runningJobCount returns how many of the run's jobs are currently running.
+func runningJobCount(run *livekit.SimulationRun) int {
+	n := 0
+	for _, j := range run.GetJobs() {
+		if j.GetStatus() == livekit.SimulationRun_Job_STATUS_RUNNING {
+			n++
+		}
+	}
+	return n
 }

--- a/cmd/lk/simulate_health_test.go
+++ b/cmd/lk/simulate_health_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/livekit/protocol/livekit"
+	"github.com/stretchr/testify/require"
+)
+
+// Real log lines captured from a rate-limited `lk agent simulate` run.
+const (
+	quotaLineTpm = `14:20:58 WARNING livekit.agents failed to generate LLM completion: message="Error code: 429 - {'type': 'inference_quota_exceeded', 'error': 'LLM token/min rate limit exceeded, category: MaxConcurrentGatewayLLMTpm, remaining_limit: 0, current_usage: 50962, session_id: 3e685b2e, project_id: p_15lqwllkcoh, status: QuotaStatusExceeded', 'category': 'MaxConcurrentGatewayLLMTpm'}", status_code=429, retryable=True`
+	quotaLineRpm = `livekit.agents._exceptions.APIStatusError: message="Error code: 429 - {'type': 'inference_quota_exceeded', 'error': 'LLM request/min rate limit exceeded, category: MaxConcurrentGatewayLLMRpm, remaining_limit: 0, current_usage: 58, status: QuotaStatusExceeded'}", status_code=429`
+)
+
+func TestDetectQuotaExceeded(t *testing.T) {
+	tests := []struct {
+		name     string
+		logs     []string
+		want     bool
+		category string
+	}{
+		{"empty", nil, false, ""},
+		{"unrelated error", []string{"ValueError: boom", "connection reset"}, false, ""},
+		{"tpm line among noise", []string{"starting agent", quotaLineTpm, "shutting down"}, true, "MaxConcurrentGatewayLLMTpm"},
+		{"rpm line", []string{quotaLineRpm}, true, "MaxConcurrentGatewayLLMRpm"},
+		{"signal without parseable category", []string{"got inference_quota_exceeded from gateway"}, true, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectQuotaExceeded(tt.logs)
+			if !tt.want {
+				require.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			require.Equal(t, tt.category, got.category)
+		})
+	}
+}
+
+func TestQuotaInfoDescribe(t *testing.T) {
+	require.Equal(t, "LLM tokens-per-minute rate limit", (&quotaInfo{category: "MaxConcurrentGatewayLLMTpm"}).describe())
+	require.Equal(t, "LLM requests-per-minute rate limit", (&quotaInfo{category: "MaxConcurrentGatewayLLMRpm"}).describe())
+	require.Equal(t, "SomeFutureCategory rate limit", (&quotaInfo{category: "SomeFutureCategory"}).describe())
+	require.Equal(t, "an inference rate limit", (&quotaInfo{}).describe())
+}
+
+func TestSuggestConcurrency(t *testing.T) {
+	tests := []struct {
+		name        string
+		configured  int32
+		peakRunning int
+		want        int
+	}{
+		{"explicit even", 10, 0, 5},
+		{"explicit odd floors", 7, 0, 3},
+		{"explicit 1 floors at 1", 1, 0, 1},
+		{"unset uses peak", 0, 10, 5},
+		{"unset odd peak floors", 0, 5, 2},
+		{"nothing observed yet", 0, 0, 1},
+		{"explicit wins over peak", 4, 100, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, suggestConcurrency(tt.configured, tt.peakRunning))
+		})
+	}
+}
+
+func TestRunningJobCount(t *testing.T) {
+	run := &livekit.SimulationRun{Jobs: []*livekit.SimulationRun_Job{
+		{Status: livekit.SimulationRun_Job_STATUS_RUNNING},
+		{Status: livekit.SimulationRun_Job_STATUS_COMPLETED},
+		{Status: livekit.SimulationRun_Job_STATUS_RUNNING},
+	}}
+	require.Equal(t, 2, runningJobCount(run))
+	require.Equal(t, 0, runningJobCount(nil))
+}

--- a/cmd/lk/simulate_report.go
+++ b/cmd/lk/simulate_report.go
@@ -129,6 +129,9 @@ func (l *simLog) BrokenAgent() {
 
 func (l *simLog) Results(run *livekit.SimulationRun, ap *AgentProcess) {
 	writeRunResults(l.out, run, ap)
+	if l.quotaNote != "" {
+		fmt.Fprintf(l.out, "\n⚠ %s\n", l.quotaNote)
+	}
 }
 
 func writeBrokenAgentNote(w io.Writer, ap *AgentProcess) {

--- a/cmd/lk/simulate_report.go
+++ b/cmd/lk/simulate_report.go
@@ -73,6 +73,10 @@ func (l *simLog) ScenariosLoaded(g *livekit.ScenarioGroup, path string) {
 	fmt.Fprintf(l.out, "✓ Loaded %d scenarios from %s (%q)\n", len(g.GetScenarios()), path, name)
 }
 
+func (l *simLog) ConfigWarning(msg string) {
+	fmt.Fprintf(l.out, "⚠ %s\n", msg)
+}
+
 func (l *simLog) RunCreated(runID, dashboardURL string) {
 	fmt.Fprintln(l.out)
 	fmt.Fprintf(l.out, "Run:       %s\n", runID)

--- a/cmd/lk/simulate_report.go
+++ b/cmd/lk/simulate_report.go
@@ -32,6 +32,7 @@ type simLog struct {
 	info       io.Writer
 	prevStatus livekit.SimulationRun_Status
 	prevDone   int
+	quotaNote  string
 }
 
 func newSimLog(out, info io.Writer) *simLog {
@@ -75,6 +76,13 @@ func (l *simLog) ScenariosLoaded(g *livekit.ScenarioGroup, path string) {
 
 func (l *simLog) ConfigWarning(msg string) {
 	fmt.Fprintf(l.out, "⚠ %s\n", msg)
+}
+
+func (l *simLog) QuotaExceeded(desc string, suggested int) {
+	l.quotaNote = fmt.Sprintf(
+		"This run hit the project's %s (inference 429s). Try re-running with --concurrency %d.",
+		desc, suggested)
+	fmt.Fprintf(l.info, "⚠ %s\n", l.quotaNote)
 }
 
 func (l *simLog) RunCreated(runID, dashboardURL string) {

--- a/cmd/lk/simulate_report_test.go
+++ b/cmd/lk/simulate_report_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/livekit/protocol/livekit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimLogQuotaExceeded_NoteAndClosingLine(t *testing.T) {
+	var buf bytes.Buffer
+	l := newSimLog(&buf, &buf)
+
+	l.QuotaExceeded("LLM tokens-per-minute rate limit", 5)
+	require.Contains(t, buf.String(), "LLM tokens-per-minute rate limit")
+	require.Contains(t, buf.String(), "--concurrency 5")
+
+	// Results repeats the note as a closing line after the per-job output.
+	buf.Reset()
+	l.Results(&livekit.SimulationRun{}, nil)
+	require.Contains(t, buf.String(), "--concurrency 5")
+}
+
+func TestSimLogResults_NoQuotaNoteByDefault(t *testing.T) {
+	var buf bytes.Buffer
+	l := newSimLog(&buf, &buf)
+	l.Results(&livekit.SimulationRun{}, nil)
+	require.NotContains(t, buf.String(), "--concurrency")
+}

--- a/cmd/lk/simulate_test.go
+++ b/cmd/lk/simulate_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,4 +34,45 @@ func TestSimulateConfigWarnings(t *testing.T) {
 	require.Empty(t, simulateConfigWarnings(modeScenarios, 0))
 	// view mode ignores everything silently.
 	require.Empty(t, simulateConfigWarnings(modeView, 5))
+}
+
+func TestViewCommandHintUsesArgv0(t *testing.T) {
+	origArgs := os.Args
+	origServerURL := serverURL
+	t.Cleanup(func() {
+		os.Args = origArgs
+		serverURL = origServerURL
+	})
+	serverURL = cloudAPIServerURL
+
+	for _, tc := range []struct {
+		name  string
+		argv0 string
+		want  string
+	}{
+		{"plain lk", "lk", "lk agent simulate --view run_123"},
+		{"path-qualified", "/usr/local/bin/lk", "/usr/local/bin/lk agent simulate --view run_123"},
+		{"renamed binary", "lk-dev", "lk-dev agent simulate --view run_123"},
+		{"empty argv0 falls back", "", "lk agent simulate --view run_123"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Args = []string{tc.argv0}
+			require.Equal(t, tc.want, viewCommandHint("run_123"))
+		})
+	}
+}
+
+func TestViewCommandHintCarriesServerURL(t *testing.T) {
+	origArgs := os.Args
+	origServerURL := serverURL
+	t.Cleanup(func() {
+		os.Args = origArgs
+		serverURL = origServerURL
+	})
+	os.Args = []string{"lk"}
+	serverURL = "https://cloud-api.staging.livekit.io"
+
+	require.Equal(t,
+		"lk agent simulate --view run_123 --server-url https://cloud-api.staging.livekit.io",
+		viewCommandHint("run_123"))
 }

--- a/cmd/lk/simulate_test.go
+++ b/cmd/lk/simulate_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimulateConfigWarnings(t *testing.T) {
+	// -n with a scenarios file: the flag does nothing, warn.
+	warns := simulateConfigWarnings(modeScenarios, 5)
+	require.Len(t, warns, 1)
+	require.Contains(t, warns[0], "--num-simulations has no effect")
+	require.Contains(t, warns[0], "--concurrency")
+
+	// -n while generating from source: the flag is meaningful, no warning.
+	require.Empty(t, simulateConfigWarnings(modeGenerateFromSource, 5))
+	// no -n at all: no warning.
+	require.Empty(t, simulateConfigWarnings(modeScenarios, 0))
+	// view mode ignores everything silently.
+	require.Empty(t, simulateConfigWarnings(modeView, 5))
+}

--- a/cmd/lk/simulate_tui.go
+++ b/cmd/lk/simulate_tui.go
@@ -386,6 +386,9 @@ func (m *simulateModel) runSetup() tea.Cmd {
 	m.currentStep = len(m.steps)
 
 	m.reporter.BeginSetup()
+	for _, w := range c.warnings {
+		m.reporter.ConfigWarning(w)
+	}
 	if c.mode == modeScenarios && c.scenarioGroup != nil {
 		m.reporter.ScenariosLoaded(c.scenarioGroup, c.scenariosPath)
 	}
@@ -927,6 +930,10 @@ func (m *simulateModel) viewSetup() string {
 	b.WriteString("\n")
 
 	b.WriteString(m.renderSteps())
+
+	for _, w := range m.config.warnings {
+		b.WriteString(yellowStyle().Render("  ⚠ "+w) + "\n")
+	}
 
 	// in file mode the scenarios are already known, nothing is generated
 	if m.setupDone && m.err == nil && m.config.mode == modeGenerateFromSource {

--- a/cmd/lk/simulate_tui.go
+++ b/cmd/lk/simulate_tui.go
@@ -118,6 +118,26 @@ var (
 	simSpinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 )
 
+// wrapLines splits text into rows no wider than width; unknown or tiny
+// widths leave the lines unwrapped.
+func wrapLines(text string, width int) []string {
+	if width >= 20 {
+		text = lipgloss.NewStyle().Width(width).Render(text)
+	}
+	return strings.Split(text, "\n")
+}
+
+// writeWrappedLines appends text to b as one styled row per line, wrapped to
+// the window width when it is known. Rendering line by line keeps lipgloss
+// from padding the block to its widest line with trailing spaces, and
+// wrapping keeps long lines (e.g. the full agent command in an error) from
+// being hard-wrapped by the terminal, which breaks the inline layout.
+func writeWrappedLines(b *strings.Builder, style lipgloss.Style, indent, text string, width int) {
+	for _, line := range wrapLines(text, width-len(indent)-2) {
+		b.WriteString(style.Render(indent+line) + "\n")
+	}
+}
+
 // --- Message types ---
 
 type simulationRunMsg struct {
@@ -964,7 +984,7 @@ func (m *simulateModel) viewSetup() string {
 	b.WriteString(m.renderSteps())
 
 	for _, w := range m.config.warnings {
-		b.WriteString(yellowStyle().Render("  ⚠ "+w) + "\n")
+		writeWrappedLines(&b, yellowStyle(), "  ", "⚠ "+w, m.width)
 	}
 
 	// in file mode the scenarios are already known, nothing is generated
@@ -979,7 +999,7 @@ func (m *simulateModel) viewSetup() string {
 
 	if m.err != nil {
 		b.WriteString("\n")
-		b.WriteString(redStyle().Render("  "+m.err.Error()) + "\n")
+		writeWrappedLines(&b, redStyle(), "  ", m.err.Error(), m.width)
 		if m.agent != nil {
 			b.WriteString("\n")
 			b.WriteString(m.renderLogs(""))
@@ -1057,9 +1077,7 @@ func (m *simulateModel) viewFailed() string {
 	b.WriteString("\n\n")
 	b.WriteString("  " + redStyle().Bold(true).Render("Failed") + "\n\n")
 	if m.run.Error != "" {
-		for line := range strings.SplitSeq(m.run.Error, "\n") {
-			b.WriteString(redStyle().Render("  "+line) + "\n")
-		}
+		writeWrappedLines(&b, redStyle(), "  ", m.run.Error, m.width)
 	} else {
 		b.WriteString(redStyle().Render("  (no error details available)") + "\n")
 	}

--- a/cmd/lk/simulate_tui.go
+++ b/cmd/lk/simulate_tui.go
@@ -194,6 +194,12 @@ type simulateModel struct {
 	confirmQuit    bool
 	confirmQuitSel int
 
+	// inference-quota (429) dialog; shows at most once per run
+	quotaWarning   *quotaInfo
+	quotaDismissed bool
+	quotaSuggested int
+	peakRunning    int
+
 	saving    bool
 	saveInput textinput.Model
 	saveErr   string
@@ -212,6 +218,10 @@ func (m *simulateModel) hasDescription() bool {
 
 func (m *simulateModel) descriptionExpanded() bool {
 	return m.detailJobID == "" && m.showDescription && m.hasDescription()
+}
+
+func (m *simulateModel) quotaModalActive() bool {
+	return m.quotaWarning != nil && !m.quotaDismissed
 }
 
 // A run that started from a scenarios.yaml has nothing new to export.
@@ -587,6 +597,16 @@ func (m *simulateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.startTime.IsZero() && msg.run.Status == livekit.SimulationRun_STATUS_RUNNING {
 				m.startTime = time.Now()
 			}
+			if running := runningJobCount(msg.run); running > m.peakRunning {
+				m.peakRunning = running
+			}
+			if m.quotaWarning == nil && !m.quotaDismissed && m.agent != nil {
+				if info := detectQuotaExceeded(m.agent.RecentLogs(0)); info != nil {
+					m.quotaWarning = info
+					m.quotaSuggested = suggestConcurrency(m.config.concurrency, m.peakRunning)
+					m.reporter.QuotaExceeded(info.describe(), m.quotaSuggested)
+				}
+			}
 			// the worker is failing systemically: cancel the run and surface
 			// its log on exit
 			if !m.brokenAgent && agentBroken(msg.run, m.agent) {
@@ -723,6 +743,18 @@ func (m *simulateModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "esc", "q", "n":
 			m.confirmQuit = false
 		case "ctrl+c":
+			return m, tea.Quit
+		}
+		return m, nil
+	}
+	if m.quotaModalActive() {
+		switch key {
+		case "enter", "esc", "q", " ":
+			m.quotaDismissed = true
+		case "ctrl+c":
+			if m.setupCancel != nil {
+				m.setupCancel()
+			}
 			return m, tea.Quit
 		}
 		return m, nil
@@ -1818,6 +1850,9 @@ func (m *simulateModel) renderHint() string {
 	if m.saving {
 		return m.renderSaveDialog()
 	}
+	if m.quotaModalActive() {
+		return m.renderQuotaWarning()
+	}
 	var parts []string
 	switch {
 	case m.detailJobID != "":
@@ -1908,6 +1943,37 @@ func (m *simulateModel) renderSaveDialog() string {
 		Padding(0, 1).
 		Width(width).
 		Render(b.String())
+	return indentLines(box, "  ")
+}
+
+// renderQuotaWarning is the once-per-run 429 dialog: the project's inference
+// quota is exhausted, so every LLM completion — and with it every job — is
+// failing. Pinned where the hint bar renders, dismissed from the keyboard
+// (the TUI runs without mouse capture).
+func (m *simulateModel) renderQuotaWarning() string {
+	suggested := m.quotaSuggested
+	width := 56
+	if max := m.width - 8; width > max {
+		width = max
+	}
+	if width < 24 {
+		width = 24
+	}
+	body := lipgloss.NewStyle().Width(width)
+	var b strings.Builder
+	b.WriteString(boldStyle.Render("Inference quota exceeded") + "\n")
+	b.WriteString(body.Render(fmt.Sprintf(
+		"This project is hitting its %s. LLM completions are being rejected (429), and simulation jobs are failing with them.",
+		m.quotaWarning.describe())) + "\n\n")
+	b.WriteString(body.Render(fmt.Sprintf(
+		"Suggested fix: re-run with --concurrency %d", suggested)) + "\n\n")
+	btn := reverseStyle.Bold(true).Render(" Dismiss ")
+	b.WriteString(lipgloss.NewStyle().Width(width).Align(lipgloss.Center).Render(btn))
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(util.Error()).
+		Padding(0, 1).
+		Render(b.String() + "\n" + dimStyle.Render("enter/esc dismiss"))
 	return indentLines(box, "  ")
 }
 

--- a/cmd/lk/simulate_tui_test.go
+++ b/cmd/lk/simulate_tui_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/livekit/protocol/livekit"
+	"github.com/stretchr/testify/require"
+)
+
+func quotaTestModel(t *testing.T) *simulateModel {
+	t.Helper()
+	m := newSimulateModel(&simulateConfig{concurrency: 0})
+	m.setupDone = true
+	m.agent = &AgentProcess{
+		roomLogs:       map[string][]string{},
+		latestRoomByPx: map[string]string{},
+	}
+	return m
+}
+
+func runningRun(nRunning int) *livekit.SimulationRun {
+	run := &livekit.SimulationRun{Status: livekit.SimulationRun_STATUS_RUNNING}
+	for i := 0; i < nRunning; i++ {
+		run.Jobs = append(run.Jobs, &livekit.SimulationRun_Job{
+			Status: livekit.SimulationRun_Job_STATUS_RUNNING,
+		})
+	}
+	return run
+}
+
+func TestQuotaDialog_ShowsOnceAndDismisses(t *testing.T) {
+	m := quotaTestModel(t)
+
+	// Poll 1: 10 jobs running, no quota errors yet — no dialog.
+	m.Update(simulationRunMsg{run: runningRun(10)})
+	require.Nil(t, m.quotaWarning)
+	require.Equal(t, 10, m.peakRunning)
+
+	// The agent starts logging 429s; the next poll raises the dialog.
+	m.agent.appendLog(quotaLineTpm)
+	m.Update(simulationRunMsg{run: runningRun(10)})
+	require.NotNil(t, m.quotaWarning)
+	require.True(t, m.quotaModalActive())
+
+	// The dialog replaces the hint bar, names the quota, suggests half the
+	// observed peak (10/2=5), and carries the dismiss button.
+	hint := m.renderHint()
+	require.Contains(t, hint, "Inference quota exceeded")
+	require.Contains(t, hint, "tokens-per-minute")
+	require.Contains(t, hint, "--concurrency 5")
+	require.Contains(t, hint, "Dismiss")
+
+	// Enter dismisses; the dialog never comes back this run.
+	m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	require.False(t, m.quotaModalActive())
+	require.True(t, m.quotaDismissed)
+	m.Update(simulationRunMsg{run: runningRun(10)})
+	require.False(t, m.quotaModalActive())
+	require.NotContains(t, m.renderHint(), "Inference quota exceeded")
+}
+
+func TestQuotaDialog_ExplicitConcurrencyHalved(t *testing.T) {
+	m := quotaTestModel(t)
+	m.config.concurrency = 7
+	m.agent.appendLog(quotaLineRpm)
+	m.Update(simulationRunMsg{run: runningRun(7)})
+	require.True(t, m.quotaModalActive())
+	require.Contains(t, m.renderHint(), "--concurrency 3") // 7/2 floors to 3
+	require.Contains(t, m.renderHint(), "requests-per-minute")
+}
+
+func TestQuotaDialog_EscDismissesAndKeysAreCaptured(t *testing.T) {
+	m := quotaTestModel(t)
+	m.agent.appendLog(quotaLineTpm)
+	m.Update(simulationRunMsg{run: runningRun(2)})
+	require.True(t, m.quotaModalActive())
+
+	// Keys other than dismiss/quit are swallowed while the dialog is up.
+	m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	require.Equal(t, 0, m.cursor)
+	require.True(t, m.quotaModalActive())
+
+	m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	require.False(t, m.quotaModalActive())
+}

--- a/cmd/lk/simulate_tui_test.go
+++ b/cmd/lk/simulate_tui_test.go
@@ -15,12 +15,44 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/livekit/protocol/livekit"
 	"github.com/stretchr/testify/require"
 )
+
+func TestWriteWrappedLines(t *testing.T) {
+	style := lipgloss.NewStyle()
+
+	// With a known width, every rendered row fits the terminal.
+	var b strings.Builder
+	writeWrappedLines(&b, style, "  ", strings.Repeat("x", 100)+"\nshort", 40)
+	lines := strings.Split(strings.TrimRight(b.String(), "\n"), "\n")
+	require.Greater(t, len(lines), 2, "long line should wrap into multiple rows")
+	for _, line := range lines {
+		require.LessOrEqual(t, lipgloss.Width(line), 40)
+	}
+
+	// Width unknown: lines pass through unwrapped, and short lines are not
+	// padded out to the widest line.
+	b.Reset()
+	writeWrappedLines(&b, style, "  ", "aaaa\nbb", 0)
+	require.Equal(t, "  aaaa\n  bb\n", b.String())
+}
+
+func TestWrapLines(t *testing.T) {
+	// Known width: every row fits.
+	for _, line := range wrapLines(strings.Repeat("x", 90), 30) {
+		require.LessOrEqual(t, lipgloss.Width(line), 30)
+	}
+
+	// Unknown/tiny width: lines pass through untouched.
+	require.Equal(t, []string{"aaaa", "bb"}, wrapLines("aaaa\nbb", 0))
+	require.Equal(t, []string{strings.Repeat("x", 90)}, wrapLines(strings.Repeat("x", 90), 10))
+}
 
 func quotaTestModel(t *testing.T) *simulateModel {
 	t.Helper()


### PR DESCRIPTION
- Detect inference-quota (429) exhaustion in agent logs and surface it in the TUI (dismissible dialog with a suggested `--concurrency`), plain mode, and the run report.
- Warn when `--num-simulations` is ignored because `--scenarios` is set.
- Support `--view` in non-interactive mode.
- Render all error/warning output line by line, wrapped to the terminal width, fixing lipgloss padding multiline errors to their widest line (e.g. the 348-char agent command in "agent exited before registering") and hard-wrap garbage on narrow terminals.
- Use argv[0] in the printed `agent simulate --view` re-open hint, so a renamed or path-qualified `lk` is reproduced as typed.