### PR TITLE
fix(agentfs): resolve a Python venv from parent directories

### DIFF
--- a/pkg/agentfs/installed_version.go
+++ b/pkg/agentfs/installed_version.go
@@ -42,12 +42,33 @@ func FindPythonBinary(dir string, projectType ProjectType) (string, []string, er
 		}
 	}
 
-	// Check common venv locations
-	for _, venvDir := range []string{".venv", "venv"} {
-		candidate := filepath.Join(dir, venvDir, "bin", "python")
+	// An activated venv is an explicit choice by the caller and outranks
+	// anything discovered on disk.
+	if venv := os.Getenv("VIRTUAL_ENV"); venv != "" {
+		candidate := filepath.Join(venv, "bin", "python")
 		if _, err := os.Stat(candidate); err == nil {
 			return candidate, nil, nil
 		}
+	}
+
+	// Check common venv locations, walking up so an agent in a subdirectory
+	// resolves the environment its repository root owns.
+	start := dir
+	if abs, err := filepath.Abs(dir); err == nil {
+		start = abs
+	}
+	for cur := start; ; {
+		for _, venvDir := range []string{".venv", "venv"} {
+			candidate := filepath.Join(cur, venvDir, "bin", "python")
+			if _, err := os.Stat(candidate); err == nil {
+				return candidate, nil, nil
+			}
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			break
+		}
+		cur = parent
 	}
 
 	// Fall back to system python

--- a/pkg/agentfs/installed_version.go
+++ b/pkg/agentfs/installed_version.go
@@ -31,6 +31,38 @@ import (
 // will really run. Static project-file parsing (sdk_version_check.go) is the
 // fallback for when no runtime environment exists.
 
+// uvDiscoverVenv returns the virtual environment interpreter uv resolves from
+// dir, or "" if uv is unavailable or resolves something that is not a venv.
+//
+// With no venv to find, uv answers with a managed standalone interpreter that
+// has no project dependencies installed; a pyvenv.cfg beside the interpreter
+// is what distinguishes the two, and only a venv may pre-empt the search for
+// a system Python the user installed the SDK into.
+func uvDiscoverVenv(dir string) string {
+	uvPath, err := exec.LookPath("uv")
+	if err != nil {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// --offline: discovery must never reach the network, and never trigger a
+	// Python download as a side effect.
+	cmd := exec.CommandContext(ctx, uvPath, "python", "find", "--offline")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	python := strings.TrimSpace(string(out))
+	if python == "" {
+		return ""
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(python), "..", "pyvenv.cfg")); err != nil {
+		return ""
+	}
+	return python
+}
+
 // FindPythonBinary locates a Python binary for the given project type.
 func FindPythonBinary(dir string, projectType ProjectType) (string, []string, error) {
 	if projectType == ProjectTypePythonUV {
@@ -42,33 +74,19 @@ func FindPythonBinary(dir string, projectType ProjectType) (string, []string, er
 		}
 	}
 
-	// An activated venv is an explicit choice by the caller and outranks
-	// anything discovered on disk.
-	if venv := os.Getenv("VIRTUAL_ENV"); venv != "" {
-		candidate := filepath.Join(venv, "bin", "python")
+	// Defer venv discovery to uv, which honors $VIRTUAL_ENV and walks up to
+	// the enclosing project or workspace — an agent in a subdirectory has no
+	// environment of its own.
+	if venvPython := uvDiscoverVenv(dir); venvPython != "" {
+		return venvPython, nil, nil
+	}
+
+	// Check common venv locations
+	for _, venvDir := range []string{".venv", "venv"} {
+		candidate := filepath.Join(dir, venvDir, "bin", "python")
 		if _, err := os.Stat(candidate); err == nil {
 			return candidate, nil, nil
 		}
-	}
-
-	// Check common venv locations, walking up so an agent in a subdirectory
-	// resolves the environment its repository root owns.
-	start := dir
-	if abs, err := filepath.Abs(dir); err == nil {
-		start = abs
-	}
-	for cur := start; ; {
-		for _, venvDir := range []string{".venv", "venv"} {
-			candidate := filepath.Join(cur, venvDir, "bin", "python")
-			if _, err := os.Stat(candidate); err == nil {
-				return candidate, nil, nil
-			}
-		}
-		parent := filepath.Dir(cur)
-		if parent == cur {
-			break
-		}
-		cur = parent
 	}
 
 	// Fall back to system python

--- a/pkg/agentfs/installed_version.go
+++ b/pkg/agentfs/installed_version.go
@@ -63,6 +63,21 @@ func uvDiscoverVenv(dir string) string {
 	return python
 }
 
+// activatedVenvPython returns the interpreter of the activated virtual
+// environment, or "" if none is activated. uv discovery already honors
+// $VIRTUAL_ENV; checking it directly keeps that behavior when uv is absent.
+func activatedVenvPython() string {
+	venv := os.Getenv("VIRTUAL_ENV")
+	if venv == "" {
+		return ""
+	}
+	python := filepath.Join(venv, "bin", "python")
+	if _, err := os.Stat(python); err != nil {
+		return ""
+	}
+	return python
+}
+
 // FindPythonBinary locates a Python binary for the given project type.
 func FindPythonBinary(dir string, projectType ProjectType) (string, []string, error) {
 	if projectType == ProjectTypePythonUV {
@@ -74,9 +89,13 @@ func FindPythonBinary(dir string, projectType ProjectType) (string, []string, er
 		}
 	}
 
-	// Defer venv discovery to uv, which honors $VIRTUAL_ENV and walks up to
-	// the enclosing project or workspace — an agent in a subdirectory has no
-	// environment of its own.
+	if venvPython := activatedVenvPython(); venvPython != "" {
+		return venvPython, nil, nil
+	}
+
+	// Defer the rest of venv discovery to uv, which walks up to the enclosing
+	// project or workspace — an agent in a subdirectory has no environment of
+	// its own.
 	if venvPython := uvDiscoverVenv(dir); venvPython != "" {
 		return venvPython, nil, nil
 	}

--- a/pkg/agentfs/installed_version_test.go
+++ b/pkg/agentfs/installed_version_test.go
@@ -101,6 +101,29 @@ func TestFindPythonBinaryPrefersActivatedVenv(t *testing.T) {
 	}
 }
 
+// $VIRTUAL_ENV is honored without uv, so an activated environment resolves for
+// users who don't have it installed.
+func TestFindPythonBinaryPrefersActivatedVenvWithoutUv(t *testing.T) {
+	root := t.TempDir()
+	activated := filepath.Join(root, "venv")
+	if err := os.MkdirAll(filepath.Join(activated, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	python := filepath.Join(activated, "bin", "python")
+	if err := os.WriteFile(python, nil, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("VIRTUAL_ENV", activated)
+
+	got, _, err := FindPythonBinary(root, ProjectTypePythonPip)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != python {
+		t.Errorf("got %s, want %s", got, python)
+	}
+}
+
 // With no venv anywhere, uv answers with a managed standalone interpreter that
 // has no dependencies installed; resolution must reject it and keep searching.
 func TestFindPythonBinaryRejectsNonVenvInterpreter(t *testing.T) {

--- a/pkg/agentfs/installed_version_test.go
+++ b/pkg/agentfs/installed_version_test.go
@@ -16,27 +16,58 @@ package agentfs
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
 
-func writeVenv(t *testing.T, root, name string) string {
+func requireUv(t *testing.T) {
 	t.Helper()
-	bin := filepath.Join(root, name, "bin")
-	if err := os.MkdirAll(bin, 0o755); err != nil {
-		t.Fatal(err)
+	if _, err := exec.LookPath("uv"); err != nil {
+		t.Skip("uv not installed")
 	}
-	python := filepath.Join(bin, "python")
-	if err := os.WriteFile(python, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	return python
 }
 
-func TestFindPythonBinaryWalksUpToRepoVenv(t *testing.T) {
+// venvOf returns the environment root a resolved interpreter belongs to, with
+// symlinks evaluated so a /var vs /private/var temp dir compares equal.
+func venvOf(t *testing.T, python string) string {
+	t.Helper()
+	root := filepath.Dir(filepath.Dir(python))
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return root
+	}
+	return resolved
+}
+
+func wantVenv(t *testing.T, dir string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return dir
+	}
+	return resolved
+}
+
+// makeVenv creates a real virtual environment at root/name.
+func makeVenv(t *testing.T, root, name string) string {
+	t.Helper()
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("uv", "venv", "--offline", name)
+	cmd.Dir = root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("uv venv: %v\n%s", err, out)
+	}
+	return filepath.Join(root, name)
+}
+
+func TestFindPythonBinaryResolvesVenvFromSubdirectory(t *testing.T) {
+	requireUv(t)
 	t.Setenv("VIRTUAL_ENV", "")
 	root := t.TempDir()
-	want := writeVenv(t, root, ".venv")
+	venv := makeVenv(t, root, ".venv")
 	agentDir := filepath.Join(root, "examples", "myagent")
 	if err := os.MkdirAll(agentDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -46,8 +77,8 @@ func TestFindPythonBinaryWalksUpToRepoVenv(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != want {
-		t.Errorf("got %s, want %s", got, want)
+	if venvOf(t, got) != wantVenv(t, venv) {
+		t.Errorf("got %s, want an interpreter inside %s", got, venv)
 	}
 	if len(prefixArgs) != 0 {
 		t.Errorf("got prefix args %v, want none", prefixArgs)
@@ -55,17 +86,40 @@ func TestFindPythonBinaryWalksUpToRepoVenv(t *testing.T) {
 }
 
 func TestFindPythonBinaryPrefersActivatedVenv(t *testing.T) {
+	requireUv(t)
 	root := t.TempDir()
-	writeVenv(t, root, ".venv")
-	activated := filepath.Join(root, "activated")
-	want := writeVenv(t, activated, "venv")
-	t.Setenv("VIRTUAL_ENV", filepath.Join(activated, "venv"))
+	makeVenv(t, root, ".venv")
+	activated := makeVenv(t, filepath.Join(root, "elsewhere"), "venv")
+	t.Setenv("VIRTUAL_ENV", activated)
 
 	got, _, err := FindPythonBinary(root, ProjectTypePythonPip)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != want {
-		t.Errorf("got %s, want %s", got, want)
+	if venvOf(t, got) != wantVenv(t, activated) {
+		t.Errorf("got %s, want an interpreter inside %s", got, activated)
+	}
+}
+
+// With no venv anywhere, uv answers with a managed standalone interpreter that
+// has no dependencies installed; resolution must reject it and keep searching.
+func TestFindPythonBinaryRejectsNonVenvInterpreter(t *testing.T) {
+	requireUv(t)
+	t.Setenv("VIRTUAL_ENV", "")
+	agentDir := filepath.Join(t.TempDir(), "agent")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _, err := FindPythonBinary(agentDir, ProjectTypePythonPip)
+	if err != nil {
+		t.Skip("no system Python on PATH")
+	}
+	systemPython, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("no python3 on PATH")
+	}
+	if got != systemPython {
+		t.Errorf("got %s, want system python %s", got, systemPython)
 	}
 }

--- a/pkg/agentfs/installed_version_test.go
+++ b/pkg/agentfs/installed_version_test.go
@@ -1,0 +1,71 @@
+// Copyright 2025 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentfs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeVenv(t *testing.T, root, name string) string {
+	t.Helper()
+	bin := filepath.Join(root, name, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	python := filepath.Join(bin, "python")
+	if err := os.WriteFile(python, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return python
+}
+
+func TestFindPythonBinaryWalksUpToRepoVenv(t *testing.T) {
+	t.Setenv("VIRTUAL_ENV", "")
+	root := t.TempDir()
+	want := writeVenv(t, root, ".venv")
+	agentDir := filepath.Join(root, "examples", "myagent")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, prefixArgs, err := FindPythonBinary(agentDir, ProjectTypePythonPip)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+	if len(prefixArgs) != 0 {
+		t.Errorf("got prefix args %v, want none", prefixArgs)
+	}
+}
+
+func TestFindPythonBinaryPrefersActivatedVenv(t *testing.T) {
+	root := t.TempDir()
+	writeVenv(t, root, ".venv")
+	activated := filepath.Join(root, "activated")
+	want := writeVenv(t, activated, "venv")
+	t.Setenv("VIRTUAL_ENV", filepath.Join(activated, "venv"))
+
+	got, _, err := FindPythonBinary(root, ProjectTypePythonPip)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
## Problem

`lk agent simulate ./agent.py` in a subdirectory of a Python repo fails before the agent registers:

```
the agent exited before registering.
Command used to start agent: /Users/…/workstation/deps/bin/python3 -m livekit.agents start ./agent.py …
  /Users/…/python3: Error while finding module specification for 'livekit.agents'
  (ModuleNotFoundError: No module named 'livekit')
```

`agentfs.FindPythonBinary` looked for `.venv`/`venv` only inside the entrypoint directory. An agent under `examples/` has no environment of its own — it belongs to the repo root — and a `requirements.txt` project is detected as `python.pip`, so the `uv run --no-sync` path doesn't apply either. Resolution fell through to `LookPath("python3")`, which picks up whatever system interpreter is first on `PATH`, where `livekit-agents` is not installed.

## Fix

Delegate venv discovery to `uv python find` rather than reimplementing it. uv already:

- honors `$VIRTUAL_ENV`, and lets it outrank a nearer `.venv` on disk
- walks up to the enclosing project or workspace, so a subdirectory agent resolves the environment its repo root owns
- picks the nearest venv when several are in the ancestry

One caveat drives the only extra logic here: with no venv to find, `uv python find` succeeds and reports a *managed standalone* interpreter (`~/.local/share/uv/python/cpython-3.14-…`) that has no project dependencies installed. Accepting that would regress anyone who `pip install`ed the SDK into a system Python. A `pyvenv.cfg` beside the interpreter distinguishes a venv from a managed standalone, so only a real venv pre-empts the existing system-Python search. When `uv` isn't installed, behavior is unchanged.

Discovery runs `--offline` so it never reaches the network or triggers a Python download as a side effect, and costs ~20ms.

## Verification

Against a real monorepo checkout (`agents/examples/hotel_receptionist`, venv at the repo root), resolution goes from system `python3` to `agents/.venv/bin/python3`, and `ResolveInstalledSDKVersion` reports `1.6.6` instead of failing to import. Tests cover subdirectory resolution, `$VIRTUAL_ENV` precedence, and rejection of a non-venv interpreter; they skip when `uv` is absent.

## Note

A project with no environment of its own can now pick up a venv from an ancestor directory. That is the same tradeoff the Python toolchain makes, but it is a behavior change.