### PR TITLE
fix(simulate): wrap only new log lines each frame

### DIFF
--- a/cmd/lk/simulate_tui.go
+++ b/cmd/lk/simulate_tui.go
@@ -228,6 +228,11 @@ type simulateModel struct {
 	logScrollOff    int
 	logPinned       bool
 	logPinnedTotal  int
+	// wrapped whole-run log lines, kept across frames; logWrapped is how many
+	// raw lines they cover and logWrapWidth the width they were wrapped at.
+	logVisual    []string
+	logWrapped   int
+	logWrapWidth int
 	showDescription bool
 	descScrollOff   int
 	// whole-page scrolling for the main list view: the full content (header,
@@ -1926,17 +1931,31 @@ func (m *simulateModel) renderLogs(roomName string) string {
 	wrapStyle := lipgloss.NewStyle().Width(maxWidth)
 
 	var rawLines []string
+	var visualLines []string
 	if roomName != "" {
 		rawLines = m.agent.RecentRoomLogsByPrefix(0, roomName)
-	} else {
-		rawLines = m.agent.RecentLogs(0)
-	}
-	var visualLines []string
-	for _, line := range rawLines {
-		wrapped := wrapStyle.Render(line)
-		for wl := range strings.SplitSeq(wrapped, "\n") {
-			visualLines = append(visualLines, wl)
+		for _, line := range rawLines {
+			for wl := range strings.SplitSeq(wrapStyle.Render(line), "\n") {
+				visualLines = append(visualLines, wl)
+			}
 		}
+	} else {
+		// The whole-run log is append-only and reaches six figures of lines on a
+		// large run, so only the new tail is wrapped: wrapping all of it every
+		// frame costs ~8µs/line and stalls the render loop.
+		rawLines = m.agent.RecentLogs(0)
+		if m.logWrapWidth != maxWidth || m.logWrapped > len(rawLines) {
+			m.logWrapWidth = maxWidth
+			m.logWrapped = 0
+			m.logVisual = nil
+		}
+		for _, line := range rawLines[m.logWrapped:] {
+			for wl := range strings.SplitSeq(wrapStyle.Render(line), "\n") {
+				m.logVisual = append(m.logVisual, wl)
+			}
+		}
+		m.logWrapped = len(rawLines)
+		visualLines = m.logVisual
 	}
 
 	total := len(visualLines)


### PR DESCRIPTION
`renderLogs` re-wrapped the whole agent log history every frame to display `height/3` lines, so cost scaled with total log volume (~7.6µs/line). With the log pane open (Ctrl+L) on a 100-job run that is ~900ms per `View()` against an 80ms spinner tick — the TUI drops to roughly one frame per second.

Measured `View()` at 160x45, 100 jobs:

| log lines | before | after |
|---|---|---|
| 1,000 | 8.3ms | 0.3ms |
| 15,000 | 113ms | 0.3ms |
| 50,000 | 380ms | 0.3ms |
| 120,000 | ~900ms | ~1ms |

At 120k lines the `RecentLogs(0)` copy is 158µs and the lipgloss re-wrap is 917ms, so the wrap is the entire cost.

The whole-run buffer is append-only, so this caches the wrapped lines on the model and wraps only the new tail; a width change or a buffer shrink rebuilds. The per-room path (job detail view) is bounded by one conversation and is unchanged.

Verified byte-identical to the previous wrap-everything output across appends, scroll offsets, resizes and offset clamping.