### PR TITLE
fix(agent): honor log level configuration

### DIFF
--- a/autocomplete/fish_autocomplete
+++ b/autocomplete/fish_autocomplete
@@ -194,6 +194,7 @@ complete -c lk -n '__fish_seen_subcommand_from agent a; and __fish_seen_subcomma
 complete -c lk -n '__fish_seen_subcommand_from agent a; and __fish_seen_subcommand_from dev' -f -l no-reload -d 'Disable auto-reload on file changes'
 complete -c lk -n '__fish_seen_subcommand_from agent a; and __fish_seen_subcommand_from dev' -f -l help -s h -d 'show help'
 complete -x -c lk -n '__fish_seen_subcommand_from agent a; and not __fish_seen_subcommand_from init create dockerfile config deploy promote status update restart rollback logs tail delete destroy versions list secrets update-secrets private-link start dev console daemon simulate help h' -a 'console' -d 'Voice chat with an agent via mic/speakers'
+complete -c lk -n '__fish_seen_subcommand_from agent a; and __fish_seen_subcommand_from console' -f -l log-level -r -d 'Log level (TRACE, DEBUG, INFO, WARN, ERROR)'
 complete -c lk -n '__fish_seen_subcommand_from agent a; and __fish_seen_subcommand_from console' -f -l port -s p -r -d 'TCP port for agent communication'
 complete -c lk -n '__fish_seen_subcommand_from agent a; and __fish_seen_subcommand_from console' -f -l input-device -r -d 'Input device index or name substring'
 complete -c lk -n '__fish_seen_subcommand_from agent a; and __fish_seen_subcommand_from console' -f -l output-device -r -d 'Output device index or name substring'

--- a/cmd/lk/agent_log_level_test.go
+++ b/cmd/lk/agent_log_level_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+
+	"github.com/livekit/livekit-cli/v2/pkg/agentfs"
+)
+
+func findStringFlag(t *testing.T, cmd *cli.Command, name string) *cli.StringFlag {
+	t.Helper()
+	for _, flag := range cmd.Flags {
+		if stringFlag, ok := flag.(*cli.StringFlag); ok && stringFlag.Name == name {
+			return stringFlag
+		}
+	}
+	t.Fatalf("flag %q not found on %q", name, cmd.Name)
+	return nil
+}
+
+func runWithLogLevelFlag(
+	t *testing.T,
+	projectType agentfs.ProjectType,
+	argv []string,
+) []string {
+	t.Helper()
+
+	// urfave/cli flags retain parse state, so use a fresh copy of the production
+	// flag for every test invocation.
+	productionFlag := findStringFlag(t, startCommand, "log-level")
+	flag := &cli.StringFlag{
+		Name:    productionFlag.Name,
+		Usage:   productionFlag.Usage,
+		Sources: productionFlag.Sources,
+	}
+
+	var got []string
+	app := &cli.Command{
+		Name:  "lk",
+		Flags: []cli.Flag{flag},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			got = buildCLIArgs(projectType, "start", cmd)
+			return nil
+		},
+	}
+	require.NoError(t, app.Run(context.Background(), argv))
+	return got
+}
+
+func TestAgentCommandsExposeLogLevelEnvironmentVariable(t *testing.T) {
+	for _, command := range []*cli.Command{startCommand, devCommand, consoleCommand} {
+		t.Run(command.Name, func(t *testing.T) {
+			flag := findStringFlag(t, command, "log-level")
+			assert.Contains(t, flag.Sources.EnvKeys(), "LIVEKIT_LOG_LEVEL")
+		})
+	}
+}
+
+func TestAgentLogLevelEnvironmentVariableIsForwarded(t *testing.T) {
+	t.Setenv("LIVEKIT_LOG_LEVEL", "info")
+
+	assert.Equal(t,
+		[]string{"start", "--log-level", "INFO"},
+		runWithLogLevelFlag(t, agentfs.ProjectTypePythonUV, []string{"lk"}),
+	)
+	assert.Equal(t,
+		[]string{"start", "--log-level", "info"},
+		runWithLogLevelFlag(t, agentfs.ProjectTypeNode, []string{"lk"}),
+	)
+}
+
+func TestAgentLogLevelFlagOverridesEnvironmentVariable(t *testing.T) {
+	t.Setenv("LIVEKIT_LOG_LEVEL", "info")
+
+	assert.Equal(t,
+		[]string{"start", "--log-level", "ERROR"},
+		runWithLogLevelFlag(
+			t,
+			agentfs.ProjectTypePythonUV,
+			[]string{"lk", "--log-level", "error"},
+		),
+	)
+}
+
+func TestBuildConsoleArgsForwardsNormalizedLogLevel(t *testing.T) {
+	assert.Equal(t,
+		[]string{
+			"console", "--connect-addr", "127.0.0.1:9876", "--record", "--log-level", "INFO",
+		},
+		buildConsoleArgs(agentfs.ProjectTypePythonUV, "127.0.0.1:9876", true, "info"),
+	)
+	assert.Equal(t,
+		[]string{"console", "--connect-addr", "127.0.0.1:9876", "--log-level", "info"},
+		buildConsoleArgs(agentfs.ProjectTypeNode, "127.0.0.1:9876", false, "INFO"),
+	)
+}
+
+func TestBuildConsoleArgsOmitsUnsetLogLevel(t *testing.T) {
+	assert.Equal(t,
+		[]string{"console", "--connect-addr", "127.0.0.1:9876"},
+		buildConsoleArgs(agentfs.ProjectTypePythonUV, "127.0.0.1:9876", false, ""),
+	)
+}

--- a/cmd/lk/agent_run.go
+++ b/cmd/lk/agent_run.go
@@ -94,18 +94,19 @@ func init() {
 	AgentCommands[0].Commands = append(AgentCommands[0].Commands, startCommand, devCommand)
 }
 
-var agentRunFlags = []cli.Flag{
-	&cli.StringFlag{
-		Name:  "log-level",
-		Usage: "Log level (TRACE, DEBUG, INFO, WARN, ERROR)",
-	},
+func agentLogLevelFlag() *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:    "log-level",
+		Usage:   "Log level (TRACE, DEBUG, INFO, WARN, ERROR)",
+		Sources: cli.EnvVars("LIVEKIT_LOG_LEVEL"),
+	}
 }
 
 var startCommand = &cli.Command{
 	Name:      "start",
 	Usage:     "Run an agent in production mode",
 	ArgsUsage: "[entrypoint] [-- node/python-args...]",
-	Flags:     agentRunFlags,
+	Flags:     []cli.Flag{agentLogLevelFlag()},
 	Action:    runAgentStart,
 	// Leaf command whose positional arg is an entrypoint file. Drop the implicit
 	// `help` subcommand so shell completion returns nothing for the positional,
@@ -117,10 +118,13 @@ var devCommand = &cli.Command{
 	Name:      "dev",
 	Usage:     "Run an agent in development mode with auto-reload",
 	ArgsUsage: "[entrypoint] [-- node/python-args...]",
-	Flags: append(agentRunFlags, &cli.BoolFlag{
-		Name:  "no-reload",
-		Usage: "Disable auto-reload on file changes",
-	}),
+	Flags: []cli.Flag{
+		agentLogLevelFlag(),
+		&cli.BoolFlag{
+			Name:  "no-reload",
+			Usage: "Disable auto-reload on file changes",
+		},
+	},
 	Action: runAgentDev,
 	// See startCommand: hide `help` so filenames complete for the entrypoint arg.
 	HideHelpCommand: true,
@@ -234,11 +238,7 @@ func resolveCredentials(cmd *cli.Command, loadOpts ...loadOption) ([]string, err
 }
 
 func buildCLIArgs(projectType agentfs.ProjectType, subcmd string, cmd *cli.Command) []string {
-	args := []string{subcmd}
-	if logLevel := cmd.String("log-level"); logLevel != "" {
-		args = append(args, "--log-level", normalizeLogLevel(projectType, logLevel))
-	}
-	return args
+	return appendLogLevel([]string{subcmd}, projectType, cmd.String("log-level"))
 }
 
 func runAgentStart(ctx context.Context, cmd *cli.Command) error {

--- a/cmd/lk/agent_utils.go
+++ b/cmd/lk/agent_utils.go
@@ -108,12 +108,28 @@ var consoleCrashSignals = []string{
 
 // buildConsoleArgs builds the agent subprocess argv for console mode, shared by
 // `lk agent console` and the `lk agent daemon` daemon.
-func buildConsoleArgs(addr string, record bool) []string {
+func buildConsoleArgs(
+	projectType agentfs.ProjectType,
+	addr string,
+	record bool,
+	logLevel string,
+) []string {
 	args := []string{"console", "--connect-addr", addr}
 	if record {
 		args = append(args, "--record")
 	}
-	return args
+	return appendLogLevel(args, projectType, logLevel)
+}
+
+func appendLogLevel(
+	args []string,
+	projectType agentfs.ProjectType,
+	logLevel string,
+) []string {
+	if logLevel == "" {
+		return args
+	}
+	return append(args, "--log-level", normalizeLogLevel(projectType, logLevel))
 }
 
 // normalizeLogLevel adapts the log level to the agent runtime's convention:

--- a/cmd/lk/console.go
+++ b/cmd/lk/console.go
@@ -47,6 +47,7 @@ var consoleCommand = &cli.Command{
 	// native filename completion for the entrypoint arg (see startCommand).
 	HideHelpCommand: true,
 	Flags: []cli.Flag{
+		agentLogLevelFlag(),
 		&cli.IntFlag{
 			Name:    "port",
 			Aliases: []string{"p"},
@@ -145,7 +146,12 @@ func runConsole(ctx context.Context, cmd *cli.Command) error {
 		Entrypoint:  entrypoint,
 		ProjectType: projectType,
 		RuntimeArgs: forwardedArgs(cmd),
-		CLIArgs:     buildConsoleArgs(actualAddr, cmd.Bool("record")),
+		CLIArgs: buildConsoleArgs(
+			projectType,
+			actualAddr,
+			cmd.Bool("record"),
+			cmd.String("log-level"),
+		),
 		FailSignals: consoleCrashSignals,
 	})
 	if err != nil {

--- a/cmd/lk/session_daemon.go
+++ b/cmd/lk/session_daemon.go
@@ -49,11 +49,12 @@ func runSessionDaemon() {
 
 	// startAgent branches on ProjectType, so Node entrypoints run as
 	// `node <entry> console ...` without any extra wiring here.
+	projectType := agentfs.ProjectType(os.Getenv(envSessionPType))
 	agentProc, err := startAgent(AgentStartConfig{
 		Dir:         os.Getenv(envSessionDir),
 		Entrypoint:  os.Getenv(envSessionEntry),
-		ProjectType: agentfs.ProjectType(os.Getenv(envSessionPType)),
-		CLIArgs:     buildConsoleArgs(server.Addr().String(), false),
+		ProjectType: projectType,
+		CLIArgs:     buildConsoleArgs(projectType, server.Addr().String(), false, ""),
 		FailSignals: consoleCrashSignals,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- read `LIVEKIT_LOG_LEVEL` for `lk agent start`, `dev`, and `console`, while preserving explicit flag precedence
- expose `--log-level` on `lk agent console`
- normalize and forward the selected level for Python and Node agent runtimes
- preserve the daemon's existing default behavior and update generated fish completion

Fixes #934.

Python thin-console support is provided by livekit/agents#6766.

## Testing

- `go test -race ./...`
- `go vet ./...`
- `make`
- regenerated fish completion and verified it matches `autocomplete/fish_autocomplete`
