### PR TITLE
simulate: give the agent under test the defaults it has deployed

### DIFF
--- a/cmd/lk/simulate.go
+++ b/cmd/lk/simulate.go
@@ -514,6 +514,13 @@ func startSimulationAgent(c *simulateConfig, forwardOutput io.Writer) (*AgentPro
 			"LIVEKIT_URL=" + c.pc.URL,
 			"LIVEKIT_API_KEY=" + c.pc.APIKey,
 			"LIVEKIT_API_SECRET=" + c.pc.APISecret,
+			// the agent under test is spawned locally, so the SDK reads it as
+			// neither hosted nor dev and falls back to the local v1-mini turn
+			// detector and VAD interruption. Deployed, the same agent gets cloud
+			// EOT and adaptive interruption; simulating the weaker pair measures
+			// turn-taking the user will never ship. This env var is what the SDK
+			// gates both defaults on.
+			"LIVEKIT_DEV_MODE=1",
 		},
 		ReadySignal:   "registered worker",
 		ForwardOutput: forwardOutput,


### PR DESCRIPTION
A locally spawned agent is neither hosted nor dev, so the SDK falls back to the local v1-mini turn detector and VAD interruption. Deployed, the same agent gets cloud EOT and adaptive interruption — so a simulation measures turn-taking the user will never ship: mid-readout commits on a spoken date, and every "mm-hmm" taken as a turn. The SDK gates both defaults on this one variable.