### PR TITLE
fix(simulate): mark a cited tool output where it prints

### DIFF
--- a/cmd/lk/simulate_tui.go
+++ b/cmd/lk/simulate_tui.go
@@ -1931,16 +1931,23 @@ func (m *simulateModel) renderChatTranscript(jobID string) string {
 			}
 			writeToolItem(&b, fmt.Sprintf("ƒ %s(%s)", fc.Name, m.toolArguments(fc.Arguments)), wrapWidth, mark)
 		case *agent.ChatContext_ChatItem_FunctionCallOutput:
-			if !m.showToolDetail {
+			fco := v.FunctionCallOutput
+			// a jump has to land on the turn it cited, so a cited output prints
+			// whether or not tool detail is on
+			mark := ""
+			if m.citedItem(fco.Id) {
+				cited = true
+				mark = citedMark()
+			}
+			if !m.showToolDetail && mark == "" {
 				continue
 			}
-			fco := v.FunctionCallOutput
 			output := strings.TrimSpace(fco.Output)
 			if output == "" {
 				continue
 			}
 			ensureAgentBlock()
-			writeToolItem(&b, "→ "+output, wrapWidth, "")
+			writeToolItem(&b, "→ "+output, wrapWidth, mark)
 		case *agent.ChatContext_ChatItem_AgentHandoff:
 			h := v.AgentHandoff
 			old := ""


### PR DESCRIPTION
The run summary can cite a tool output (`function_call_output`) with a `<ref>`. Pressing that citation's digit opened the job but never marked the turn: `renderChatTranscript` skipped tool outputs unless tool detail was toggled on, and when it did print them it passed an empty mark, so the reader saw either "the cited turn is not in this transcript" or an unmarked output.

A cited output now prints whether or not tool detail is on, and carries the `◀ cited` mark like a cited function call does. Uncited outputs keep hiding behind the toggle.

Whether the stored history carries an id for tool outputs is up to the agent-service summarizer; livekit/agents-private#396 fixes that side. Runs summarized before it deploys still cite ids the history doesn't have and keep showing the "not in this transcript" line.

Verified with `go vet` and `go test ./cmd/lk` (system portaudio).
