### PR TITLE
chore(build): ignore cross-compile artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ dist/
 
 # Local artifacts
 .task/
+.zig-cache/
 
 .DS_Store
 /lk


### PR DESCRIPTION
Dirty `.zig-cache/` from failed CI runs can break release workflow, so explicitly ignore it.