### PR TITLE
fix(cli): Fix project add not respecting --default flag

### DIFF
--- a/cmd/lk/project.go
+++ b/cmd/lk/project.go
@@ -232,7 +232,7 @@ func addProject(ctx context.Context, cmd *cli.Command) error {
 	// if it's first project, make it default
 	isDefault := false
 	if cmd.Bool("default") || defaultProject == nil {
-		cliConfig.DefaultProject = p.Name
+		isDefault = true
 	} else if !cmd.IsSet("default") {
 		prompts = append(prompts, util.Confirm().
 			Title("Make this project default?").
@@ -251,9 +251,10 @@ func addProject(ctx context.Context, cmd *cli.Command) error {
 		if err != nil {
 			return err
 		}
-		if isDefault {
-			cliConfig.DefaultProject = p.Name
-		}
+	}
+
+	if isDefault {
+		cliConfig.DefaultProject = p.Name
 	}
 
 	cliConfig.Projects = append(cliConfig.Projects, p)


### PR DESCRIPTION
When creating a project, I noticed that the `--default` flag is not respected unless the project name is passed as an argument to the command. It tries to set the default project to the project's name, but it hasn't prompted for a project name yet, so it sets it to empty string.

This fix produces what I assume is the intended behavior.