### PR TITLE
ci: one cross-build runner per target, one target per OS on PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,18 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      # PRs build one target per OS; main covers all four before release.
-      # fromJSON is required, not decorative: a matrix value must be an array,
-      # and the expression language has no array literal — only boolean, null,
-      # number and string — so a list that varies by event has to arrive as
-      # parsed JSON.
       matrix:
-        id: |-
-          ${{ case(
-            github.event_name == 'pull_request',
-            fromJSON('["lk-linux-amd64", "lk-windows-amd64"]'),
-            fromJSON('["lk-linux-amd64", "lk-linux-arm64", "lk-windows-amd64", "lk-windows-arm64"]')
-          ) }}
+        id: [lk-linux-amd64, lk-linux-arm64, lk-windows-amd64, lk-windows-arm64]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -120,6 +120,21 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
+          # setup-go's `cache` defaults to true, which collides with test.yaml's
+          # macos leg — that job wins the key and stores `-race` objects this
+          # non-race build can't reuse. Own cache below.
+          cache: false
+
+      - name: Cache Go modules and build cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          # GOCACHE is under ~/Library/Caches on darwin, not ~/.cache.
+          path: |
+            ~/go/pkg/mod
+            ~/Library/Caches/go-build
+          key: go-${{ runner.os }}-darwin-build-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-darwin-build-
 
       - name: Build and verify
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,12 @@ jobs:
       # number and string — so a list that varies by event has to arrive as
       # parsed JSON.
       matrix:
-        id: ${{ github.event_name == 'pull_request' && fromJSON('["lk-linux-amd64", "lk-windows-amd64"]') || fromJSON('["lk-linux-amd64", "lk-linux-arm64", "lk-windows-amd64", "lk-windows-arm64"]') }}
+        id: |-
+          ${{ case(
+            github.event_name == 'pull_request',
+            fromJSON('["lk-linux-amd64", "lk-windows-amd64"]'),
+            fromJSON('["lk-linux-amd64", "lk-linux-arm64", "lk-windows-amd64", "lk-windows-arm64"]')
+          ) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,10 @@ jobs:
     strategy:
       fail-fast: false
       # PRs build one target per OS; main covers all four before release.
+      # fromJSON is required, not decorative: a matrix value must be an array,
+      # and the expression language has no array literal — only boolean, null,
+      # number and string — so a list that varies by event has to arrive as
+      # parsed JSON.
       matrix:
         id: ${{ github.event_name == 'pull_request' && fromJSON('["lk-linux-amd64", "lk-windows-amd64"]') || fromJSON('["lk-linux-amd64", "lk-linux-arm64", "lk-windows-amd64", "lk-windows-arm64"]') }}
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,25 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
+          # setup-go's default cache key is keyed only on OS/arch/go version/
+          # go.sum, so it collides with the Go Test workflow's. Test finishes
+          # first, claims the key, and this job's save then fails with "Unable
+          # to reserve cache" — leaving it to restore native-gcc `go test -race`
+          # objects that no zig cross target can use. Own cache below instead.
+          cache: false
+
+      - name: Cache Go modules and build cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-${{ matrix.id }}-${{ hashFiles('go.sum') }}
+          # A go.sum bump changes the key but leaves the webrtc/portaudio C++
+          # objects — the expensive part — valid, so fall back to any build of
+          # this target.
+          restore-keys: |
+            go-${{ runner.os }}-${{ matrix.id }}-
 
       - name: Install Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,10 +24,17 @@ permissions:
   contents: read
 
 jobs:
-  # Linux + Windows are cross-compiled with zig on a (cheap) Linux runner.
+  # Linux + Windows are cross-compiled with zig on (cheap) Linux runners, one
+  # target per runner — a single runner compiling all four serializes ~560 C/C++
+  # translation units (webrtc APM + portaudio) per target onto 4 vCPUs.
   cross-build:
-    name: Cross-build linux+windows (zig)
+    name: Cross-build ${{ matrix.id }} (zig)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # PRs build one target per OS; main covers all four before release.
+      matrix:
+        id: ${{ github.event_name == 'pull_request' && fromJSON('["lk-linux-amd64", "lk-windows-amd64"]') || fromJSON('["lk-linux-amd64", "lk-linux-arm64", "lk-windows-amd64", "lk-windows-arm64"]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -47,7 +54,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .cross
-          key: cross-${{ runner.os }}-zig0.14.1-alsa1.2.12-${{ hashFiles('scripts/setup-cross.sh') }}
+          key: cross-${{ runner.os }}-${{ matrix.id }}-zig0.14.1-alsa1.2.12-${{ hashFiles('scripts/setup-cross.sh') }}
 
       - name: GoReleaser snapshot build
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
@@ -56,10 +63,7 @@ jobs:
           version: latest
           # darwin is excluded here — it can't be cross-compiled from Linux
           # (no macOS SDK/CoreAudio); it builds natively in the macos job below.
-          args: >-
-            build --snapshot --clean
-            --id lk-linux-amd64 --id lk-linux-arm64
-            --id lk-windows-amd64 --id lk-windows-arm64
+          args: build --snapshot --clean --id ${{ matrix.id }}
         env:
           # goreleaser-action runs goreleaser via a Node wrapper that doesn't
           # forward PWD; the .goreleaser.yaml CGO flags template {{ .Env.PWD }}
@@ -67,6 +71,7 @@ jobs:
           PWD: ${{ github.workspace }}
 
       - name: Verify linux binary runs
+        if: matrix.id == 'lk-linux-amd64'
         run: |
           binary=$(find dist -type f -name lk -path '*linux*amd64*' | head -n1)
           test -n "$binary" || { echo "no linux/amd64 binary in dist/"; exit 1; }

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -51,7 +51,23 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
-          cache: true
+          # setup-go's default key carries no workflow or job component, so this
+          # job and test.yaml generate the same one. Test finishes first and
+          # claims it; the save here then fails with "Unable to reserve cache",
+          # leaving this job to restore native-gcc objects no zig target can use.
+          cache: false
+
+      - name: Cache Go modules and build cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-windows-cross-${{ hashFiles('go.sum') }}
+          # A go.sum bump leaves the webrtc/portaudio C++ objects — the
+          # expensive part — valid, so fall back to any earlier build.
+          restore-keys: |
+            go-${{ runner.os }}-windows-cross-
 
       # Generate the MinGW import libs lld needs for Go's /DEFAULTLIB references
       # (dbghelp, bcrypt, ...), exactly as goreleaser's before-hook does.


### PR DESCRIPTION
The `Cross-build linux+windows (zig)` job takes ~19 minutes, ~17 of which are a single `GoReleaser snapshot build` step. It compiles all four zig cross targets in one goreleaser invocation on one `ubuntu-latest` (4 vCPU) runner:

- 445 `.cc`/`.c` under `pkg/apm` + 114 under `pkg/portaudio` ≈ 560 translation units
- × 4 targets = ~2,240 C++ compiles at `-O2` through `zig cc`
- 17 min × 4 cores ÷ 4 targets ≈ 1.8 s/TU — a cold WebRTC APM build, every run

Nothing is reused between runs either: `setup-go`'s cache key is an exact `go.sum` hash with no `restore-keys`, and even when it hits (699 MB restored in [run 33115504417](https://github.com/livekit/livekit-cli/actions/runs/33115504417)) the step still took 19m19s vs 19m45s cold.

This PR does the cheap structural half:

1. **Matrix the four targets** so each gets its own runner instead of sharing 4 vCPUs. Same total CPU, ~4× less wall clock.
2. **Build one target per OS on PRs** (`lk-linux-amd64`, `lk-windows-amd64`); pushes to `main` still build all four, so nothing reaches a release untested.

The `.cross` cache key gains the target id, since each runner now populates only its own `.cross/<target>/`.

Expected: ~19 min → ~5 min on PRs.

Not addressed here: why a warm 699 MB `GOCACHE` buys nothing. Worth a follow-up.