### PR TITLE
ci(release): one runner per target, reuse build.yaml's warm caches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,9 +122,9 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/Library/Caches/go-build
-          key: go-${{ runner.os }}-darwin-build-${{ hashFiles('go.sum') }}
+          key: go-${{ runner.os }}-lk-darwin-${{ hashFiles('go.sum') }}
           restore-keys: |
-            go-${{ runner.os }}-darwin-build-
+            go-${{ runner.os }}-lk-darwin-
 
       - name: Build and verify
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,21 +23,11 @@ permissions:
   contents: write
 
 jobs:
-  # GoReleaser runs on macOS so the darwin binary builds natively (CoreAudio
-  # frameworks only exist on a Mac); zig still cross-compiles linux + windows
-  # from here. Produces all binaries, archives, checksums, and the GitHub
-  # release. Docker is handled by the separate job below (macOS has no Docker).
-  release:
-    name: Release
-    runs-on: macos-latest
+  verify:
+    name: Verify versions
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout Git LFS
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          lfs: 'true'
-          # pkg/portaudio/pa_src holds the vendored PortAudio C source the cgo
-          # build links against.
-          submodules: true
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Verify version.go matches tag
         run: |
@@ -70,56 +60,133 @@ jobs:
           fi
           echo "versions match ($livekit_cli_major_minor)"
 
-      - run: git lfs pull
+  # Same shape as build.yaml: each zig cross target gets its own Linux runner
+  # and restores the per-target GOCACHE the push to main just warmed (the cache
+  # keys and paths below must stay identical to build.yaml's for that to hit).
+  # darwin builds natively on macOS (CoreAudio frameworks only exist on a Mac).
+  build:
+    name: Build ${{ matrix.id }}
+    needs: verify
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - { id: lk-linux-amd64, os: ubuntu-latest, gocache: ~/.cache/go-build }
+          - { id: lk-linux-arm64, os: ubuntu-latest, gocache: ~/.cache/go-build }
+          - { id: lk-windows-amd64, os: ubuntu-latest, gocache: ~/.cache/go-build }
+          - { id: lk-windows-arm64, os: ubuntu-latest, gocache: ~/.cache/go-build }
+          - { id: lk-darwin, os: macos-latest, gocache: ~/Library/Caches/go-build }
+    steps:
+      - name: Checkout Git LFS
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          lfs: 'true'
+          # pkg/portaudio/pa_src holds the vendored PortAudio C source the cgo
+          # build links against.
+          submodules: true
 
-      - name: Fetch all tags
-        run: git fetch --force --tags
+      - run: git lfs pull
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
-          cache: true
+          # setup-go's default cache key collides with the Go Test workflow's,
+          # which stores `-race` objects no build here can reuse. Own cache below.
+          cache: false
+
+      - name: Cache Go modules and build cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            ~/go/pkg/mod
+            ${{ matrix.gocache }}
+          key: go-${{ runner.os }}-${{ matrix.id }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-${{ matrix.id }}-
 
       - name: Install Zig
+        if: runner.os == 'Linux'
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.14.1
 
       - name: Cache cross-compile inputs
+        if: runner.os == 'Linux'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .cross
-          key: cross-${{ runner.os }}-zig0.14.1-alsa1.2.12-${{ hashFiles('scripts/setup-cross.sh') }}
+          key: cross-${{ runner.os }}-${{ matrix.id }}-zig0.14.1-alsa1.2.12-${{ hashFiles('scripts/setup-cross.sh') }}
 
-      - name: Run GoReleaser
+      - name: GoReleaser build
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          args: build --clean --id ${{ matrix.id }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # goreleaser-action runs goreleaser via a Node wrapper that doesn't
           # forward PWD; the .goreleaser.yaml CGO flags template {{ .Env.PWD }}
           # to locate .cross/<target>. Provide it explicitly.
           PWD: ${{ github.workspace }}
 
-      - name: Stage linux binaries for Docker
+      # goreleaser OSS can't archive binaries built elsewhere (that's the Pro
+      # `prebuilt` builder), so each job archives its own output in the layout
+      # `goreleaser release` produced: lk_<version>_<os>_<arch>.{tar.gz,zip}
+      # containing LICENSE, autocomplete/ and the binary at the root.
+      - name: Package archives
         run: |
-          mkdir -p docker-bin
-          cp dist/lk-linux-amd64_*/lk docker-bin/lk_linux_amd64
-          cp dist/lk-linux-arm64_*/lk docker-bin/lk_linux_arm64
+          version=${GITHUB_REF_NAME#v}
+          mkdir -p archives
+          jq -r '.[] | select(.type == "Binary") | [.goos, .goarch, .path] | @tsv' dist/artifacts.json |
+          while IFS=$'\t' read -r goos goarch path; do
+            stage=$(mktemp -d)
+            cp "$path" LICENSE "$stage/"
+            cp -R autocomplete "$stage/"
+            name="lk_${version}_${goos}_${goarch}"
+            if [ "$goos" = windows ]; then
+              (cd "$stage" && zip -qr "$GITHUB_WORKSPACE/archives/$name.zip" LICENSE autocomplete lk.exe)
+            else
+              tar -czf "archives/$name.tar.gz" -C "$stage" LICENSE autocomplete lk
+            fi
+            echo "packaged archives/$name"
+          done
+          ls -l archives
 
-      - name: Upload linux binaries
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: docker-bin
-          path: docker-bin/
+          name: archives-${{ matrix.id }}
+          path: archives/
           if-no-files-found: error
 
+  release:
+    name: Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: archives-*
+          merge-multiple: true
+          path: archives
+
+      - name: Create checksums
+        run: cd archives && sha256sum * > checksums.txt && cat checksums.txt
+
+      # Draft, like goreleaser's `release.draft: true`; a prerelease suffix on
+      # the tag marks it prerelease, like `prerelease: auto`.
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          prerelease=()
+          case "$GITHUB_REF_NAME" in *-*) prerelease=(--prerelease) ;; esac
+          gh release create "$GITHUB_REF_NAME" --draft --generate-notes --title "$GITHUB_REF_NAME" \
+            "${prerelease[@]}" archives/*
+
   # Build + push multi-arch Docker images on Linux (where the Docker daemon
-  # lives), reusing the cgo linux binaries staged by the release job.
+  # lives), reusing the cgo linux binaries from the linux build jobs.
   docker:
     name: Release to Docker
     needs: release
@@ -128,14 +195,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Download linux binaries
+      - name: Download linux archives
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: docker-bin
-          path: .
+          pattern: archives-lk-linux-*
+          merge-multiple: true
+          path: archives
 
-      - name: Restore executable bit
-        run: chmod +x lk_linux_amd64 lk_linux_arm64
+      - name: Stage linux binaries
+        run: |
+          for arch in amd64 arm64; do
+            tar -xzf archives/lk_*_linux_${arch}.tar.gz lk
+            mv lk lk_linux_${arch}
+          done
 
       - name: Docker meta
         id: meta

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,23 +28,13 @@ builds:
   # builds where goreleaser runs (the macOS release runner). On the arm64 macOS
   # runner, amd64 cross-compiles via Apple clang's -arch against the universal
   # SDK. The build.yaml smoke test builds both arches the same way.
-  - id: lk-darwin-amd64
+  - id: lk-darwin
     main: ./cmd/lk
     binary: lk
     env:
       - CGO_ENABLED=1
     goos: [darwin]
-    goarch: [amd64]
-    ldflags:
-      - -s -w
-
-  - id: lk-darwin-arm64
-    main: ./cmd/lk
-    binary: lk
-    env:
-      - CGO_ENABLED=1
-    goos: [darwin]
-    goarch: [arm64]
+    goarch: [amd64, arm64]
     ldflags:
       - -s -w
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Consumed by the docker job in release.yaml via `docker buildx`. The release
-# job (goreleaser, on macOS) cross-builds the cgo Linux binaries with zig and
-# stages them as lk_linux_<arch> in the build context; buildx sets TARGETARCH
-# per platform. Distroless gives glibc (the binaries target glibc 2.28+) plus CA
+# Consumed by the docker job in release.yaml via `docker buildx`. The linux
+# build jobs (goreleaser + zig) cross-build the cgo Linux binaries and the
+# docker job stages them as lk_linux_<arch> in the build context; buildx sets
+# TARGETARCH per platform. Distroless gives glibc (the binaries target glibc 2.28+) plus CA
 # certs, without a shell or package manager.
 FROM gcr.io/distroless/base-debian12
 


### PR DESCRIPTION
The `Release` job for [v2.18.5](https://github.com/livekit/livekit-cli/actions/runs/33659969355/job/100347822287) took 39 minutes, 36m43s of it in `Run GoReleaser`. v2.18.4 and v2.18.3 look the same, so this is not a regression: #951 moved the PR/main Build workflow to one runner per zig target with per-target `GOCACHE` caches, but `release.yaml` kept the pre-#951 shape:

- one `macos-latest` runner (3 vCPU) compiling darwin plus all four zig cross targets in a single goreleaser run; the cross targets took 11 to 22 minutes each, two at a time, while both darwin builds finished in ~2 minutes
- `setup-go`'s default cache (`cache: true`), whose key is only OS/arch/Go version/go.sum and so collides with the Go Test workflow's macOS leg. Test claims the key first with native `-race` objects, `actions/cache` never overwrites on a hit, and the release restored 702 MB of objects no zig target could use, every release. This is the same collision `build.yaml` already documents and opts out of.

The warm cache does work for zig targets once it actually contains their objects. Build runs on `main` since #951: 267s to 401s per target on the first (cold) run, 22s to 60s on every run since, including the 712b1f71 run that preceded this tag.

### Change

- `build` job: a matrix of the four zig targets on `ubuntu-latest` plus `lk-darwin` on `macos-latest`, each running `goreleaser build --id <target>`. The `GOCACHE` and `.cross` cache keys and paths are identical to `build.yaml`'s so the tag build restores what the push to `main` just saved (caches on the default branch are readable from tag refs). No new cache footprint, which matters because the repo's Actions cache sits at 9.8 GB of the 10 GB quota.
- goreleaser OSS has no `prebuilt` builder or `--split`, so each job archives its own binaries in the layout `goreleaser release` produced (`lk_<version>_<os>_<arch>.tar.gz` / `.zip` with `LICENSE`, `autocomplete/` and the binary at the root), and a final `release` job writes `checksums.txt` (same `sha256sum` format) and runs `gh release create --draft --generate-notes`, with `--prerelease` when the tag has a prerelease suffix. Published releases already use GitHub's generated notes, so the body format is unchanged.
- The docker job extracts the linux binaries from the linux archives instead of a separate artifact.
- The two identical darwin build IDs are merged into one `lk-darwin` id (separate commit) so one macOS job builds both arches. `build.yaml`'s darwin cache key is renamed to `go-<os>-lk-darwin-` so both workflows share it.

Verified locally: `goreleaser check`, `goreleaser build --snapshot --id lk-darwin`, and the `Package archives` step against its output produce the same archive layout as the v2.18.4 assets.

Expected: ~39 min → ~5 min when caches are warm, ~8 min cold.
