### PR TITLE
feat(simulate): add --list to show the project's simulation runs

### DIFF
--- a/cmd/lk/simulate.go
+++ b/cmd/lk/simulate.go
@@ -97,6 +97,11 @@ var simulateCommand = &cli.Command{
 			Name:  "view",
 			Usage: "Open a pre-existing simulation",
 		},
+		&cli.BoolFlag{
+			Name:  "list",
+			Usage: "List the project's simulation runs, newest first. Nothing is run",
+		},
+		jsonFlag,
 		&cli.StringFlag{
 			Name:  "export",
 			Usage: "Print the run with run `ID` and its exact per-job chat contexts as JSON. Nothing is run or polled: the run must already be finished",
@@ -317,6 +322,9 @@ func runSimulate(ctx context.Context, cmd *cli.Command, simulationMode livekit.S
 			return fmt.Errorf("--export requires a run ID")
 		}
 		return exportSimulationRunJSON(ctx, pc, exportRunID)
+	}
+	if cmd.Bool("list") {
+		return listSimulationRuns(ctx, pc, cmd.Bool("json"))
 	}
 
 	numSimulations := int32(cmd.Int("num-simulations"))
@@ -645,6 +653,60 @@ func getSimulationRun(ctx context.Context, client *lksdk.AgentSimulationClient, 
 		return nil, err
 	}
 	return resp.Run, nil
+}
+
+// listSimulationRuns prints the first page the API returns, which is already
+// newest-first; older runs live in the dashboard.
+func listSimulationRuns(ctx context.Context, pc *config.ProjectConfig, asJSON bool) error {
+	client := lksdk.NewAgentSimulationClient(serverURL, pc.APIKey, pc.APISecret)
+
+	fetchCtx, cancel := context.WithTimeout(ctx, simulationAPITimeout)
+	defer cancel()
+	resp, err := client.ListSimulationRuns(fetchCtx, &livekit.SimulationRun_List_Request{
+		ProjectId: pc.ProjectId,
+	})
+	if err != nil {
+		return err
+	}
+	if asJSON {
+		util.PrintJSON(resp)
+		return nil
+	}
+
+	table := util.CreateTable().
+		Headers("ID", "Created", "Agent", "Mode", "Status", "Passed", "Failed", "Jobs")
+	for _, run := range resp.Runs {
+		table.Row(simulationRunRow(run)...)
+	}
+	out.Result(table)
+	if len(resp.Runs) == 0 {
+		out.Status("No simulation runs yet.")
+		return nil
+	}
+	out.Statusf("To open a run: %s", viewCommandHint("<ID>"))
+	return nil
+}
+
+// SimulationRun.mode defines UNSPECIFIED as TEXT.
+func simulationRunRow(run *livekit.SimulationRun) []string {
+	mode := run.GetMode()
+	if mode == livekit.SimulationMode_SIMULATION_MODE_UNSPECIFIED {
+		mode = livekit.SimulationMode_SIMULATION_MODE_TEXT
+	}
+	created := "--"
+	if run.CreatedAt != nil {
+		created = formatTime(run.CreatedAt.AsTime())
+	}
+	return []string{
+		run.GetId(),
+		created,
+		run.GetAgentName(),
+		strings.TrimPrefix(mode.String(), "SIMULATION_MODE_"),
+		strings.TrimPrefix(run.GetStatus().String(), "STATUS_"),
+		fmt.Sprint(run.GetPassedCount()),
+		fmt.Sprint(run.GetFailedCount()),
+		fmt.Sprint(run.GetJobCount()),
+	}
 }
 
 func isTerminalRunStatus(status livekit.SimulationRun_Status) bool {

--- a/cmd/lk/simulate_list_test.go
+++ b/cmd/lk/simulate_list_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/livekit/protocol/livekit"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestSimulationRunRow(t *testing.T) {
+	created := time.Date(2026, 9, 8, 17, 0, 0, 0, time.UTC)
+	row := simulationRunRow(&livekit.SimulationRun{
+		Id:          "run_123",
+		CreatedAt:   timestamppb.New(created),
+		AgentName:   "my-agent",
+		Mode:        livekit.SimulationMode_SIMULATION_MODE_AUDIO,
+		Status:      livekit.SimulationRun_STATUS_COMPLETED,
+		JobCount:    5,
+		PassedCount: 4,
+		FailedCount: 1,
+	})
+	require.Equal(t, []string{"run_123", "2026-09-08T17:00:00Z", "my-agent", "AUDIO", "COMPLETED", "4", "1", "5"}, row)
+}
+
+func TestSimulationRunRowUnspecifiedModeIsText(t *testing.T) {
+	row := simulationRunRow(&livekit.SimulationRun{Id: "run_1"})
+	require.Equal(t, "TEXT", row[3])
+	require.Equal(t, "--", row[1])
+}


### PR DESCRIPTION
`lk agent simulate --view <ID>` needs a run ID, and the only place to find one was the dashboard. Requested in #project-simulations: https://live-kit.slack.com/archives/C0A2DQNKQPN/p1788886841297879

`lk agent simulate --list` prints the project's simulation runs newest-first (ID, created, agent, mode, status, passed/failed/total jobs) and exits without running anything. `--json` prints the raw `ListSimulationRuns` response instead. It short-circuits every other flag the same way `--export` does.

```
$ lk agent simulate --list
┌─────────────────┬──────────────────────┬─────────────────────┬──────┬───────────┬────────┬────────┬──────┐
│ ID              │ Created              │ Agent               │ Mode │ Status    │ Passed │ Failed │ Jobs │
├─────────────────┼──────────────────────┼─────────────────────┼──────┼───────────┼────────┼────────┼──────┤
│ SR_8ZrYPxdFjAfR │ 2026-09-01T20:13:48Z │ simulation-ziy42v9d │ TEXT │ COMPLETED │ 3      │ 0      │ 3    │
│ SR_v22sNDpQNCN7 │ 2026-08-25T12:54:07Z │ simulation-d0fp8qes │ TEXT │ COMPLETED │ 12     │ 4      │ 16   │
└─────────────────┴──────────────────────┴─────────────────────┴──────┴───────────┴────────┴────────┴──────┘
To open a run: lk agent simulate --view <ID>
```

Only the first page is shown; older runs stay in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
